### PR TITLE
N°4528 - Fix Unique Names for Persons autocreated from Incoming Mail

### DIFF
--- a/datamodel.itop-standard-email-synchro.xml
+++ b/datamodel.itop-standard-email-synchro.xml
@@ -364,6 +364,10 @@ EOF
 						$sAttCode = trim($aMatches[1]);
 						$sValue = trim($aMatches[2]);
 						$aDefaultValues[$sAttCode] = $sValue;
+						if ($sAttCode == 'name')
+						{
+							$aDefaultValues[$sAttCode] .= ' - AUTOCREATED FOR: '.($oEmail->sCallerEmail);
+						}
 					}
 				}
 				$this->InitObjectFromDefaultValues($oCaller, $aDefaultValues);


### PR DESCRIPTION
Hi Combodo,

### Summary

Currently, the default values one has to set for incoming mails from unknown persons in a Mailbox lead to a violation of the (soft) uniqueness-requirement for a Persons Name. This PR adds the email-address of the unknown contact to the `name`-Attribute of a Person to prevent this from happening, as it is creating database inconsistencies.

### Things tried before

I started with a suggestion from Vincent to add a timestamp to the `name`-Attribute, when it is created. But since PHP is fast, I noticed, when creating the timestamp by calling `time()` on two different mails with two different mailadresses, but which are handled in the same background-loop, the values are equal. 

(See the green bars for the new code):
![image](https://user-images.githubusercontent.com/21227916/214067419-31075e9a-1f42-4720-a39b-f9f869a08a40.png)

Result:
![image](https://user-images.githubusercontent.com/21227916/214067622-c3871a10-2aa1-41ce-a23b-c645e5218f7e.png)

I then tried the same with `microtime()`, but quickly noticed, this will cause a lot of confusion, because no-one can make sense from those values:
![image](https://user-images.githubusercontent.com/21227916/214067929-578bb6e8-2192-4b88-900d-e91cfafda772.png)

I then thought again and noticed: We already a unique identifier at hand: the mailaddress of the contact itself. So, why not use it to prevent the violation _and_ make the autocreated contacts somewhat "filterable" (e. g. for audits) by being able to search for `AUTOCREATED FOR:`?

Result:
![image](https://user-images.githubusercontent.com/21227916/214068843-61d32bf6-8268-4153-8f3b-c5633d393a10.png)


### Summary
It is an as-simple-as-possible-fix. I hope, it is enough, to address this (small) need.

### Notes
- I've opted to append this unique string to the attribute `name`, as I think, it is unlikely, someone will delete or modify this field in iTop. - But please let me know, if you see the need to first figure out, if this field still is of type `AttributeString`.
- Do we need to manually limit the length to 255 chars, or does iTop already do that? The UI maxes out at 255.

Martin