### PR TITLE
N°6863 - Allow mail inbox administrator to choose log attribute in which updates will be added

### DIFF
--- a/datamodel.itop-standard-email-synchro.xml
+++ b/datamodel.itop-standard-email-synchro.xml
@@ -63,6 +63,11 @@
           <default_value/>
           <is_null_allowed>true</is_null_allowed>
         </field>
+        <field id="ticket_updates_log_attcode" xsi:type="AttributeString">
+          <sql>ticket_updates_log_attcode</sql>
+          <default_value>public_log</default_value>
+          <is_null_allowed>false</is_null_allowed>
+        </field>
         <field id="title_pattern" xsi:type="AttributeString">
           <sql>title_pattern</sql>
           <default_value/>
@@ -833,7 +838,7 @@ EOF
 		}
 					
 		// Determine which field to update
-		$sAttCode = 'public_log';
+		$sAttCode = $this->Get('ticket_updates_log_attcode');
 		$aAttCodes = MetaModel::GetModuleSetting('itop-standard-email-synchro', 'ticket_log', array('UserRequest' => 'public_log', 'Incident' => 'public_log'));
 		if (array_key_exists(get_class($oTicket), $aAttCodes))
 		{
@@ -1475,6 +1480,9 @@ EOF
                     </item>
                     <item id="ticket_default_title">
                       <rank>60</rank>
+                    </item>
+                    <item id="ticket_updates_log_attcode">
+                      <rank>65</rank>
                     </item>
                     <item id="title_pattern">
                       <rank>70</rank>

--- a/en.dict.itop-standard-email-synchro.php
+++ b/en.dict.itop-standard-email-synchro.php
@@ -44,6 +44,8 @@ Dict::Add('EN US', 'English', 'English', array(
 
 	'Class:MailInboxStandard/Attribute:ticket_default_values' => 'Ticket Default Values',
 	'Class:MailInboxStandard/Attribute:ticket_default_title' => 'Default Title (if subject is empty)',
+	'Class:MailInboxStandard/Attribute:ticket_updates_log_attcode' => 'Ticket log for new messages',
+	'Class:MailInboxStandard/Attribute:ticket_updates_log_attcode+' => 'Attribute code of the log (eg. public_log, private_log, ...) in which new messages will be added',
 	'Class:MailInboxStandard/Attribute:title_pattern+' => 'Pattern to match in the subject',
 	'Class:MailInboxStandard/Attribute:title_pattern' => 'Title Pattern',
 	'Class:MailInboxStandard/Attribute:title_pattern?' => 'Use PCRE syntax, including starting and ending delimiters',

--- a/fr.dict.itop-standard-email-synchro.php
+++ b/fr.dict.itop-standard-email-synchro.php
@@ -36,6 +36,8 @@ Dict::Add('FR FR', 'French', 'Français', array(
 
 	'Class:MailInboxStandard/Attribute:ticket_default_values' => 'Valeurs par défaut du Ticket',
 	'Class:MailInboxStandard/Attribute:ticket_default_title' => 'Titre par défaut (en cas de sujet vide)',
+	'Class:MailInboxStandard/Attribute:ticket_updates_log_attcode' => 'Journal pour nouveaux messages',
+	'Class:MailInboxStandard/Attribute:ticket_updates_log_attcode+' => 'Code de l\'attribut (ex : public_log, private_log, ...) qui sera utilisé pour ajouter les nouveaux messages',
 	'Class:MailInboxStandard/Attribute:title_pattern+' => 'Expression régulière à rechercher dans l\'objet de l\'eMail',
 	'Class:MailInboxStandard/Attribute:title_pattern' => 'Recherche dans l\'objet du mail (RegExp)',
 	'Class:MailInboxStandard/Attribute:title_pattern?' => 'Utilisez la syntaxe PCRE avec les délimiteurs de début et de fin',


### PR DESCRIPTION
**Objective**
Allow mail inbox administrator to choose log attribute in which updates will be added

**Use case**
  * 1 mail inbox for caller creation / updates in the public log
  * 1 mail inbox for provider (dispatched) updates in another log

The idea is to avoid the end-user to be aware of the provider updates

**Proposed solution**
  * De-hardcoded the target log attribute and display it in the mail inbox object
  * Set default value to "public_log" for backward compatibility
  * As the class is defined in XML, use a string attribute to allow setting any log attribute, not just public_log / private_log