### PR TITLE
N°7340 - Fix no contact added when multiple contact occurences for email address

### DIFF
--- a/datamodel.itop-standard-email-synchro.xml
+++ b/datamodel.itop-standard-email-synchro.xml
@@ -713,7 +713,7 @@ EOF
 			default:
 			$this->Trace('Found '.$oSet->Count().' contacts with the same email address in To/CC "'.$sEmail.'", the first one will be used...');
 			// Multiple contacts with the same email address !!!
-			$oCaller = $oSet->Fetch();
+			$oContact = $oSet->Fetch();
 		}
 		return $oContact;
 	}]]></code>


### PR DESCRIPTION
Removed unnecessary variable "$oCaller" in favor of the correct variable "$oContact," which can be returned after the switch case.

The variable "$oCaller" was deemed unnecessary as it cannot be returned. Utilizing the correct variable "$oContact" ensures the appropriate value is returned after the switch case.