### PR TITLE
Feature/9437 update closed tickets

### DIFF
--- a/datamodel.itop-standard-email-synchro.xml
+++ b/datamodel.itop-standard-email-synchro.xml
@@ -151,6 +151,16 @@
           <default_value/>
           <is_null_allowed>true</is_null_allowed>
         </field>
+        <field id="behavior_closed_ticket" xsi:type="AttributeEnum">
+          <sql>behavior_closed_ticket</sql>
+          <values>
+            <value>error</value>
+            <value>new_ticket</value>
+            <value>update_ticket</value>
+          </values>
+          <default_value>new_ticket</default_value>
+          <is_null_allowed>false</is_null_allowed>
+        </field>
       </fields>
       <methods>
         <method id="DisplayBareRelations">
@@ -428,13 +438,20 @@ EOF
 						$this->Trace("iTop Simple Email Synchro: WARNING the message ({$oEmail->sUIDL}) got a EmailReplica#{$oEmailReplica->GetKey()}
 						with the ticket_id={$oEmailReplica->Get('ticket_id')} but the ticket does not exist.");
 					} elseif (MetaModel::IsValidAttCode(get_class($oTicket), "operational_status") && $oTicket->Get("operational_status") === "closed") {
-						$this->Trace("iTop Simple Email Synchro: WARNING the message ({$oEmail->sUIDL}) is related to the CLOSED (operational_status) ticket {$oTicket->Get('id')}");
-						return null;
+						if ($this->Get('behavior_closed_ticket') === 'new_ticket') {
+                $this->Trace("iTop Simple Email Synchro: WARNING the message ({$oEmail->sUIDL}) is related to the CLOSED (operational_status) ticket {$oTicket->Get('id')}");
+                return null;
+						} else {
+                return $oTicket;
+						}
 					} elseif (MetaModel::IsValidAttCode(get_class($oTicket), "status") && $oTicket->Get("status") === "closed") {
-						$this->Trace("iTop Simple Email Synchro: WARNING the message ({$oEmail->sUIDL}) is related to the CLOSED (status) ticket {$oTicket->Get('id')}");
-						return null;
-					}
-					else {
+	          if ($this->Get('behavior_closed_ticket') === 'new_ticket') {
+                $this->Trace("iTop Simple Email Synchro: WARNING the message ({$oEmail->sUIDL}) is related to the CLOSED (status) ticket {$oTicket->Get('id')}");
+                return null;
+						} else {
+                return $oTicket;
+						}
+					} else {
 					  return $oTicket;
 					}
 				}
@@ -444,22 +461,33 @@ EOF
 			// No associated ticket found by parsing the headers, check
 			// if the subject does not match a specific pattern
 			$sPattern = $this->FixPattern($this->Get('title_pattern'));
-			if(($sPattern != '') && (preg_match($sPattern, $oEmail->sSubject, $aMatches)))
-			{
+			if(($sPattern != '') && (preg_match($sPattern, $oEmail->sSubject, $aMatches))) {
 				$oFilter = DBSearch::FromOQL('SELECT Ticket WHERE ref = :ref');
-				foreach ($aMatches as $sMatch)
-				{
-					if (!empty($sMatch))
-					{
+				foreach ($aMatches as $sMatch) {
+					if (!empty($sMatch)) {
 						$this->Trace("iTop Simple Email Synchro: Retrieving ticket $sMatch (match by subject pattern)...");
 						$oSet = new DBObjectSet($oFilter, array(), array('ref' => $sMatch));
 						$oTicket = $oSet->Fetch();
-						if ($oTicket)
-						{
+						if ($oTicket) {
+              if (MetaModel::IsValidAttCode(get_class($oTicket), "operational_status") && $oTicket->Get("operational_status") === "closed") {
+                if ($this->Get('behavior_closed_ticket') === 'new_ticket') {
+                    $this->Trace("iTop Simple Email Synchro: WARNING the message ({$oEmail->sUIDL}) is related to the CLOSED (operational_status) ticket {$oTicket->Get('id')}");
+                    return null;
+                } else {
+                    return $oTicket;
+                }
+              } elseif (MetaModel::IsValidAttCode(get_class($oTicket), "status") && $oTicket->Get("status") === "closed") {
+                if ($this->Get('behavior_closed_ticket') === 'new_ticket') {
+                    $this->Trace("iTop Simple Email Synchro: WARNING the message ({$oEmail->sUIDL}) is related to the CLOSED (status) ticket {$oTicket->Get('id')}");
+                    return null;
+                } else {
+                    return $oTicket;
+                }
+              }
 							break;
 						}
-				    }
-                }
+				  }
+        }
 			}
 
 		return $oTicket;
@@ -536,7 +564,7 @@ EOF
 
 		// Insert the remaining attachments so that we know their ID and can reference them in the message's body
 		$aAddedAttachments = $this->AddAttachments($oTicket, $oEmail, true, $aIgnoredAttachments, $oCaller, $oUser);  // Cannot insert them for real since the Ticket is not saved yet (we don't know its ID)
-																									// we'll have to call UpdateAttachments once the ticket is properly saved
+		// we'll have to call UpdateAttachments once the ticket is properly saved
 		$oTicketDescriptionAttDef = MetaModel::GetAttributeDef(get_class($oTicket), 'description');
 		$bForPlainText = true; // Target format is plain text (by default)
 		if ($oTicketDescriptionAttDef instanceof AttributeHTML)
@@ -798,6 +826,15 @@ EOF
 			$this->SetNextAction(EmailProcessor::MARK_MESSAGE_AS_ERROR); // Keep the message in the mailbox, but marked as error
 			return;
 		}
+		if($this->Get('behavior_closed_ticket') === 'error'){
+      if (MetaModel::IsValidAttCode(get_class($oTicket), "operational_status") && $oTicket->Get('operational_status') =='closed'){
+          $this->sLastError='Ticket '.$oTicket->GetName().' is closed. Cannot update a closed ticket.';
+          return null;
+      } elseif (MetaModel::IsValidAttCode(get_class($oTicket), "status") && $oTicket->Get("status") === "closed") {
+          $this->sLastError='Ticket '.$oTicket->GetName().' is closed. Cannot update a closed ticket.';
+          return null;
+      }
+    }
 		
 		// Try to extract what's new from the message's body
 		$this->Trace("iTop Simple Email Synchro: Updating the iTop ticket ".$oTicket->GetName()." from eMail '".$oEmail->sSubject."'");
@@ -1462,6 +1499,9 @@ EOF
                   <items>
                     <item id="behavior">
                       <rank>10</rank>
+                    </item>
+                    <item id="behavior_closed_ticket">
+                      <rank>15</rank>
                     </item>
                     <item id="email_storage">
                       <rank>20</rank>

--- a/datamodel.itop-standard-email-synchro.xml
+++ b/datamodel.itop-standard-email-synchro.xml
@@ -82,6 +82,11 @@
           <default_value/>
           <is_null_allowed>true</is_null_allowed>
         </field>
+        <field id="unknown_caller_rejection_reply_subject" xsi:type="AttributeString">
+          <sql>unknown_caller_rejection_reply_subject</sql>
+          <default_value/>
+          <is_null_allowed>true</is_null_allowed>
+        </field>
         <field id="caller_default_values" xsi:type="AttributeText">
           <sql>caller_default_values</sql>
           <default_value/>
@@ -151,16 +156,26 @@
           <default_value/>
           <is_null_allowed>true</is_null_allowed>
         </field>
-        <field id="behavior_closed_ticket" xsi:type="AttributeEnum">
-          <sql>behavior_closed_ticket</sql>
+        <field id="closed_ticket_behavior" xsi:type="AttributeEnum">
+          <sql>closed_ticket_behavior</sql>
           <values>
-            <value>error_with_autoreply</value>
             <value>error</value>
+            <value>process</value>
             <value>new_ticket</value>
             <value>update_ticket</value>
           </values>
           <default_value>new_ticket</default_value>
           <is_null_allowed>false</is_null_allowed>
+        </field>
+        <field id="closed_ticket_reply_subject" xsi:type="AttributeString">
+          <sql>closed_ticket_reply_subject</sql>
+          <default_value/>
+          <is_null_allowed>true</is_null_allowed>
+        </field>
+        <field id="closed_ticket_reply" xsi:type="AttributeText">
+          <sql>closed_ticket_reply</sql>
+          <default_value/>
+          <is_null_allowed>true</is_null_allowed>
         </field>
       </fields>
       <methods>
@@ -262,7 +277,7 @@ EOF
           <type>Overload-DBObject</type>
           <code><![CDATA[	public function ProcessNewEmail(EmailSource $oSource, $index, EmailMessage $oEmail)
 	{
-	    $this->sLastError = null;
+	   $this->sLastError = null;
 		$this->Trace("Processing new eMail (index = $index)");
 		$oTicket = null;
 		if ($this->IsUndesired($oEmail))
@@ -438,22 +453,8 @@ EOF
 					if (is_null($oTicket)) {
 						$this->Trace("iTop Simple Email Synchro: WARNING the message ({$oEmail->sUIDL}) got a EmailReplica#{$oEmailReplica->GetKey()}
 						with the ticket_id={$oEmailReplica->Get('ticket_id')} but the ticket does not exist.");
-					} elseif (MetaModel::IsValidAttCode(get_class($oTicket), "operational_status") && $oTicket->Get("operational_status") === "closed") {
-						if ($this->Get('behavior_closed_ticket') === 'new_ticket') {
-                $this->Trace("iTop Simple Email Synchro: WARNING the message ({$oEmail->sUIDL}) is related to the CLOSED (operational_status) ticket {$oTicket->Get('id')}");
-                return null;
-						} else {
-                return $oTicket;
-						}
-					} elseif (MetaModel::IsValidAttCode(get_class($oTicket), "status") && $oTicket->Get("status") === "closed") {
-	          if ($this->Get('behavior_closed_ticket') === 'new_ticket') {
-                $this->Trace("iTop Simple Email Synchro: WARNING the message ({$oEmail->sUIDL}) is related to the CLOSED (status) ticket {$oTicket->Get('id')}");
-                return null;
-						} else {
-                return $oTicket;
-						}
 					} else {
-					  return $oTicket;
+					   return $this->CheckTicketStatus($oTicket);
 					}
 				}
 			}
@@ -470,27 +471,66 @@ EOF
 						$oSet = new DBObjectSet($oFilter, array(), array('ref' => $sMatch));
 						$oTicket = $oSet->Fetch();
 						if ($oTicket) {
-              if (MetaModel::IsValidAttCode(get_class($oTicket), "operational_status") && $oTicket->Get("operational_status") === "closed") {
-                if ($this->Get('behavior_closed_ticket') === 'new_ticket') {
-                    $this->Trace("iTop Simple Email Synchro: WARNING the message ({$oEmail->sUIDL}) is related to the CLOSED (operational_status) ticket {$oTicket->Get('id')}");
-                    return null;
-                } else {
-                    return $oTicket;
-                }
-              } elseif (MetaModel::IsValidAttCode(get_class($oTicket), "status") && $oTicket->Get("status") === "closed") {
-                if ($this->Get('behavior_closed_ticket') === 'new_ticket') {
-                    $this->Trace("iTop Simple Email Synchro: WARNING the message ({$oEmail->sUIDL}) is related to the CLOSED (status) ticket {$oTicket->Get('id')}");
-                    return null;
-                } else {
-                    return $oTicket;
-                }
-              }
-							break;
+               return $this->CheckTicketStatus($oTicket,$oEmail);
 						}
 				  }
         }
 			}
 
+		return $oTicket;
+	}]]></code>
+        </method>
+        <method id="CheckTicketStatus">
+          <comment><![CDATA[/**
+	 * Check id ticket is closed and apply the appropriate behavior
+	 * @param $oTicket
+	 * @return string
+	 */]]></comment>
+          <static>false</static>
+          <access>protected</access>
+          <type>Overload-DBObject</type>
+          <code><![CDATA[	protected function CheckTicketStatus($oTicket, $oEmail)
+	{
+		if ((MetaModel::IsValidAttCode(get_class($oTicket), "operational_status") && $oTicket->Get("operational_status") === "closed") ||
+		    (MetaModel::IsValidAttCode(get_class($oTicket), "status") && $oTicket->Get("status") === "closed")) {
+          //send mail if configured to do so
+        $sReplyBody = $this->Get('closed_ticket_reply');
+        $sReplySubject = $this->Get('closed_ticket_reply_subject');
+        if (utils::IsNotNullOrEmptyString($sReplyBody)|| utils::IsNotNullOrEmptyString($sReplySubject) ) {
+            $sContactQuery = 'SELECT Person WHERE email = :email';
+            $oSet = new DBObjectSet(DBObjectSearch::FromOQL($sContactQuery), array(), array('email' => $oEmail->sCallerEmail));
+            $oPerson = $oSet->Fetch();
+            $aPlaceholders = [
+                '$subject$',
+                '$senderEmail$',
+                '$senderName$',
+                '$senderFirstName$'
+            ];
+            $aReplacement = [
+                $oEmail->sSubject,
+                $oEmail->sCallerEmail,
+                $oPerson->Get('name'),
+                $oPerson->Get('first_name'),
+            ];
+            //replace the only autorized placeholder $subject$
+            if (utils::IsNullOrEmptyString($sReplySubject)){
+                  $sReplySubject = 'Re: '.$oEmail->sSubject;
+            } else {
+                  $sReplySubject = str_replace($aPlaceholders,$aReplacement, $sReplySubject);
+            }
+            $sReplyBody = str_replace($aPlaceholders, $aReplacement, $sReplyBody);
+            $sReplyBody = str_replace("\n", "<br/>", $sReplyBody);
+            $sReplyTo = $oEmail->sCallerEmail;
+            $sReplyFrom = $oEmail->aTos[0]['email'];
+            $this->Trace("From: ".$sReplyFrom."\nTo: ".$sReplyTo."\n".$sReplySubject."\n\n".$sReplyBody);
+            $oEmail->oRawEmail->SendAsAttachment($sReplyTo, $sReplyFrom, $sReplySubject, $sReplyBody);
+        }
+
+		    if ($this->Get('closed_ticket_behavior') === 'new_ticket') {
+                $this->Trace("iTop Simple Email Synchro: WARNING the message ({$oEmail->sUIDL}) is related to the CLOSED (operational_status) ticket {$oTicket->Get('id')}");
+                return null;
+				}
+		}
 		return $oTicket;
 	}]]></code>
         </method>
@@ -827,32 +867,29 @@ EOF
 			$this->SetNextAction(EmailProcessor::MARK_MESSAGE_AS_ERROR); // Keep the message in the mailbox, but marked as error
 			return;
 		}
-		if($this->Get('behavior_closed_ticket') === 'error' || $this->Get('behavior_closed_ticket') === 'error_with_autoreply'){
+		if($this->Get('closed_ticket_behavior') === 'error'){
       if ((MetaModel::IsValidAttCode(get_class($oTicket), "operational_status") && $oTicket->Get('operational_status') =='closed') || (MetaModel::IsValidAttCode(get_class($oTicket), "status") && $oTicket->Get("status") === "closed")) {
-          $this->sLastError='Ticket '.$oTicket->GetName().' is closed. Cannot update a closed ticket.';
-          if ($this->Get('behavior_closed_ticket') === 'error_with_autoreply') {
-                $oResponseEMail = new EMail();
-                $sNewSubject = Dict::Format('itop-standard-email-synchro:email_subject_error_closed_ticket', $oEmail->sSubject);
-                $sToEmail = $oEmail->sCallerEmail;
-                $oResponseEMail->SetSubject($sNewSubject);
-                $oResponseEMail->SetBody(Dict::S('itop-standard-email-synchro:email_message_error_closed_ticket').$oEmail->sBodyText, $oEmail->sBodyFormat);
-                $oResponseEMail->SetRecipientTO($sToEmail);
-                $oResponseEMail->SetRecipientCC([]);
-                $oResponseEMail->SetRecipientBCC([]);
-                $oResponseEMail->SetRecipientFrom(	MetaModel::GetConfig()->Get('email_default_sender_address'),	MetaModel::GetConfig()->Get('email_default_sender_label'));
-                foreach($oEmail->aReferences as $sReference) {
-                  $oResponseEMail->SetReferences($sReference);
-                }
-
-                $oNew = MetaModel::NewObject('AsyncSendEmail');
-                $oNew->Set('to', $sToEmail);
-                $oNew->Set('subject', $sNewSubject);
-                $oNew->Set('version', 2);
-                $sMessage = $oResponseEMail->SerializeV2();
-                $oNew->Set('message', $sMessage);
-                $oNew->DBInsert();
-         }
+            $this->sLastError='Ticket '.$oTicket->GetName().' is closed. Cannot update a closed ticket.';
           return null;
+      }
+    }
+		if($this->Get('closed_ticket_behavior') === 'process'){
+      if ((MetaModel::IsValidAttCode(get_class($oTicket), "operational_status") && $oTicket->Get('operational_status') =='closed') || (MetaModel::IsValidAttCode(get_class($oTicket), "status") && $oTicket->Get("status") === "closed")) {
+           $this->Trace("iTop Simple Email Synchro: WARNING the message ({$oEmail->sUIDL}) is related to the CLOSED (operational_status) ticket {$oTicket->Get('id')}");
+          // process the mail as usual but do not update the ticket
+          if ($this->Get('email_storage') == 'delete')	{
+            // Remove the processed message from the mailbox
+            $this->Trace("Ticket updated, deleting the source eMail '".$oEmail->sSubject."'");
+            $this->SetNextAction(EmailProcessor::DELETE_MESSAGE);
+          } else	if ($this->Get('email_storage') == 'move')	{
+            // Remove the processed message from the mailbox
+            $this->Trace("Ticket created, move the source eMail '".$oEmail->sSubject."'");
+            $this->SetNextAction(EmailProcessor::MOVE_MESSAGE);
+          } else {
+            // Keep the message in the mailbox
+            $this->SetNextAction(EmailProcessor::NO_ACTION);
+          }
+          return $oTicket;
       }
     }
 		
@@ -1261,6 +1298,7 @@ EOF
           <type>Overload-DBObject</type>
           <code><![CDATA[	public function HandleError($oEmail, $sErrorCode, $oRawEmail = null, $sAdditionalErrorMessage = '')
 	{
+	  $this->Trace(json_encode(\MyHelpers::get_callstack(1)));
 		$sTo = $this->Get('notify_errors_to');
 		$sFrom = $this->Get('notify_errors_from');
 		// The behavior is overriden in case of undesired_message
@@ -1283,15 +1321,29 @@ EOF
 
 			// if rejection reply
 			$sRejectionReply = $this->Get('unknown_caller_rejection_reply');
-			if (!empty($sRejectionReply) && $oRawEmail)
+			$sRejectionReplySubject = $this->Get('unknown_caller_rejection_reply_subject');
+			if ((utils::IsNotNullOrEmptyString($sRejectionReply) || utils::IsNotNullOrEmptyString($sRejectionReplySubject)) && $oRawEmail)
 			{
-			    $sReplySubject = '[iTop] '.$oEmail->sSubject.' - '.$this->sLastError;
+			 $aPlaceholders = [
+                '$subject$',
+                '$senderEmail$'
+            ];
+            $aReplacement = [
+                $oEmail->sSubject,
+                $oEmail->sCallerEmail
+            ];
+	        if (utils::IsNullOrEmptyString($sRejectionReplySubject)){
+	              $sRejectionReplySubject =  '[iTop] '.$oEmail->sSubject.' - '.$this->sLastError;
+	        } else {
+			          $sRejectionReplySubject = str_replace($aPlaceholders, $aReplacement, $sRejectionReplySubject);
+			    }
+			    $sRejectionReply = str_replace($aPlaceholders, $aReplacement, $sRejectionReply);
 			    $sReplyBody = str_replace("\n", "<br/>", $sRejectionReply);
 			    $sReplyTo = $oEmail->sCallerEmail;
 			    $aTo = $oRawEmail->GetTo();
 			    $sReplyFrom = $aTo[0]['email'];
-			    $this->Trace("From: ".$sReplyFrom."\nTo: ".$sReplyTo."\n".$sReplySubject."\n\n".$sReplyBody);
-			    $oRawEmail->SendAsAttachment($sReplyTo, $sReplyFrom, $sReplySubject, $sReplyBody);
+			    $this->Trace("From: ".$sReplyFrom."\nTo: ".$sReplyTo."\n".$sRejectionReplySubject."\n\n".$sReplyBody);
+			    $oRawEmail->SendAsAttachment($sReplyTo, $sReplyFrom, $sRejectionReplySubject, $sReplyBody);
 
 			    $this->sLastError .= " - Replied to sender on ".date('r');
 			}
@@ -1520,15 +1572,17 @@ EOF
                     <item id="behavior">
                       <rank>10</rank>
                     </item>
-                    <item id="behavior_closed_ticket">
-                      <rank>15</rank>
-                    </item>
                     <item id="email_storage">
                       <rank>20</rank>
                     </item>
                     <item id="target_folder">
                       <rank>30</rank>
                     </item>
+                  </items>
+                </item>
+                <item id="fieldset:MailInbox:TicketProcessing">
+                  <rank>20</rank>
+                  <items>
                     <item id="target_class">
                       <rank>40</rank>
                     </item>
@@ -1546,11 +1600,32 @@ EOF
                     </item>
                   </items>
                 </item>
+                <item id="fieldset:MailInbox:ClosedTickets">
+                  <rank>30</rank>
+                  <items>
+                    <item id="closed_ticket_behavior">
+                      <rank>40</rank>
+                    </item>
+                    <item id="closed_ticket_reply_subject">
+                      <rank>50</rank>
+                    </item>
+                    <item id="closed_ticket_reply">
+                      <rank>60</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
+            </item>
+            <item id="col:col2">
+              <items>
                 <item id="fieldset:MailInbox:Caller">
-                  <rank>20</rank>
+                  <rank>10</rank>
                   <items>
                     <item id="unknown_caller_behavior">
                       <rank>10</rank>
+                    </item>
+                    <item id="unknown_caller_rejection_reply_subject">
+                      <rank>14</rank>
                     </item>
                     <item id="unknown_caller_rejection_reply">
                       <rank>15</rank>

--- a/datamodel.itop-standard-email-synchro.xml
+++ b/datamodel.itop-standard-email-synchro.xml
@@ -154,6 +154,7 @@
         <field id="behavior_closed_ticket" xsi:type="AttributeEnum">
           <sql>behavior_closed_ticket</sql>
           <values>
+            <value>error_with_autoreply</value>
             <value>error</value>
             <value>new_ticket</value>
             <value>update_ticket</value>
@@ -826,12 +827,31 @@ EOF
 			$this->SetNextAction(EmailProcessor::MARK_MESSAGE_AS_ERROR); // Keep the message in the mailbox, but marked as error
 			return;
 		}
-		if($this->Get('behavior_closed_ticket') === 'error'){
-      if (MetaModel::IsValidAttCode(get_class($oTicket), "operational_status") && $oTicket->Get('operational_status') =='closed'){
+		if($this->Get('behavior_closed_ticket') === 'error' || $this->Get('behavior_closed_ticket') === 'error_with_autoreply'){
+      if ((MetaModel::IsValidAttCode(get_class($oTicket), "operational_status") && $oTicket->Get('operational_status') =='closed') || (MetaModel::IsValidAttCode(get_class($oTicket), "status") && $oTicket->Get("status") === "closed")) {
           $this->sLastError='Ticket '.$oTicket->GetName().' is closed. Cannot update a closed ticket.';
-          return null;
-      } elseif (MetaModel::IsValidAttCode(get_class($oTicket), "status") && $oTicket->Get("status") === "closed") {
-          $this->sLastError='Ticket '.$oTicket->GetName().' is closed. Cannot update a closed ticket.';
+          if ($this->Get('behavior_closed_ticket') === 'error_with_autoreply') {
+                $oResponseEMail = new EMail();
+                $sNewSubject = Dict::Format('itop-standard-email-synchro:email_subject_error_closed_ticket', $oEmail->sSubject);
+                $sToEmail = $oEmail->sCallerEmail;
+                $oResponseEMail->SetSubject($sNewSubject);
+                $oResponseEMail->SetBody(Dict::S('itop-standard-email-synchro:email_message_error_closed_ticket').$oEmail->sBodyText, $oEmail->sBodyFormat);
+                $oResponseEMail->SetRecipientTO($sToEmail);
+                $oResponseEMail->SetRecipientCC([]);
+                $oResponseEMail->SetRecipientBCC([]);
+                $oResponseEMail->SetRecipientFrom(	MetaModel::GetConfig()->Get('email_default_sender_address'),	MetaModel::GetConfig()->Get('email_default_sender_label'));
+                foreach($oEmail->aReferences as $sReference) {
+                  $oResponseEMail->SetReferences($sReference);
+                }
+
+                $oNew = MetaModel::NewObject('AsyncSendEmail');
+                $oNew->Set('to', $sToEmail);
+                $oNew->Set('subject', $sNewSubject);
+                $oNew->Set('version', 2);
+                $sMessage = $oResponseEMail->SerializeV2();
+                $oNew->Set('message', $sMessage);
+                $oNew->DBInsert();
+         }
           return null;
       }
     }

--- a/dictionaries/cs.dict.itop-standard-email-synchro.php
+++ b/dictionaries/cs.dict.itop-standard-email-synchro.php
@@ -20,7 +20,7 @@ Dict::Add('CS CZ', 'Czech', 'Čeština', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
 - Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
 - Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.

--- a/dictionaries/cs.dict.itop-standard-email-synchro.php
+++ b/dictionaries/cs.dict.itop-standard-email-synchro.php
@@ -20,16 +20,21 @@ Dict::Add('CS CZ', 'Czech', 'Čeština', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
-- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior'                     => 'Behavior in case of closed ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Mark the mail as in error
+- Mark the mail as processed, without updating the closed ticket
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:error'         => 'Mark the mail as in error~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:process'       => 'Mark the mail as processed~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:update_ticket' => 'Update the Ticket~~',
+
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject'             => 'Closed ticket autoreply subject~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject+'            => 'If no subject is provided, then the default subject will be: "Re:$subject$"
+You can use the following placeholders : $subject$, $senderName$, $senderFirstName$ and $senderEmail$ in the email subject.~~',
+
 
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
@@ -108,12 +113,19 @@ Do not activate this option for long periods on production since it tends to gen
  - Reject the eMail: flag the eMail in error and reply to the sender with the content of "Unknown senders rejection reply"~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:create_contact' => 'Create a new Person~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:reject_email' => 'Reject the eMail~~',
-	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply' => 'Unknown senders rejection reply~~',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject'  => 'Unknown senders autoreply subject',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject+' => 'If no subject is provided, then the default subject will be: "[iTop]$subject$ - Unknown caller ($senderEmail$)"
+You can use the following placeholders : $subject$ and $senderEmail$ in the email subject.',
+
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply'  => 'Unknown senders rejection reply message',
 	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply+' => 'Optional reply to sender used with option “Reject the eMail”.
 Unknown senders are email addresses which do not correspond to any Person in '.ITOP_APPLICATION_SHORT.'.
-If this field is left empty, then no message is sent to unknown senders~~',
+If this field is left empty, then no message is sent to unknown senders
+You can use the following placeholders : $subject$ and $senderEmail$ in the message.~~',
 	'MailInbox:Behavior' => 'Behavior on Incoming eMails~~',
 	'MailInbox:Caller' => 'Unknown Senders~~',
+	'MailInbox:TicketProcessing'                                        => 'Ticket Processing~~',
+	'MailInbox:ClosedTickets'                                           => 'Closed Tickets~~',
 	'MailInbox:Errors' => 'Emails in Error~~',
 	'MailInbox:NoSubject' => 'No subject~~',
 	'MailInbox:OtherContacts' => 'Behavior for Additional Contacts~~',
@@ -122,7 +134,4 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
-
-	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
-	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/cs.dict.itop-standard-email-synchro.php
+++ b/dictionaries/cs.dict.itop-standard-email-synchro.php
@@ -20,6 +20,15 @@ Dict::Add('CS CZ', 'Czech', 'Čeština', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Put the mail in error: Nothing is done. The mail is in error.
+- Create a new ticket
+- Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
+
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',

--- a/dictionaries/cs.dict.itop-standard-email-synchro.php
+++ b/dictionaries/cs.dict.itop-standard-email-synchro.php
@@ -22,10 +22,12 @@ Dict::Add('CS CZ', 'Czech', 'Čeština', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error: Nothing is done. The mail is in error.
+- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
+- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 
@@ -120,4 +122,7 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
+
+	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
+	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/da.dict.itop-standard-email-synchro.php
+++ b/dictionaries/da.dict.itop-standard-email-synchro.php
@@ -20,16 +20,21 @@ Dict::Add('DA DA', 'Danish', 'Dansk', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
-- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior'                     => 'Behavior in case of closed ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Mark the mail as in error
+- Mark the mail as processed, without updating the closed ticket
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:error'         => 'Mark the mail as in error~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:process'       => 'Mark the mail as processed~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:update_ticket' => 'Update the Ticket~~',
+
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject'             => 'Closed ticket autoreply subject~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject+'            => 'If no subject is provided, then the default subject will be: "Re:$subject$"
+You can use the following placeholders : $subject$, $senderName$, $senderFirstName$ and $senderEmail$ in the email subject.~~',
+
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',
@@ -107,12 +112,23 @@ Do not activate this option for long periods on production since it tends to gen
  - Reject the eMail: flag the eMail in error and reply to the sender with the content of "Unknown senders rejection reply"~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:create_contact' => 'Create a new Person~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:reject_email' => 'Reject the eMail~~',
-	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply' => 'Unknown senders rejection reply~~',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject'  => 'Unknown senders autoreply subject',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject+' => 'If no subject is provided, then the default subject will be: "[iTop]$subject$ - Unknown caller ($senderEmail$)"
+You can use the following placeholders : $subject$ and $senderEmail$ in the email subject.',
+
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject'  => 'Unknown senders autoreply subject',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject+' => 'If no subject is provided, then the default subject will be: "[iTop]$subject$ - Unknown caller ($senderEmail$)"
+You can use the following placeholders : $subject$ and $senderEmail$ in the email subject.',
+
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply'  => 'Unknown senders rejection reply message',
 	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply+' => 'Optional reply to sender used with option “Reject the eMail”.
 Unknown senders are email addresses which do not correspond to any Person in '.ITOP_APPLICATION_SHORT.'.
-If this field is left empty, then no message is sent to unknown senders~~',
+If this field is left empty, then no message is sent to unknown senders
+You can use the following placeholders : $subject$ and $senderEmail$ in the message.~~',
 	'MailInbox:Behavior' => 'Behavior on Incoming eMails~~',
 	'MailInbox:Caller' => 'Unknown Senders~~',
+	'MailInbox:TicketProcessing'                                        => 'Ticket Processing~~',
+	'MailInbox:ClosedTickets'                                           => 'Closed Tickets~~',
 	'MailInbox:Errors' => 'Emails in Error~~',
 	'MailInbox:NoSubject' => 'No subject~~',
 	'MailInbox:OtherContacts' => 'Behavior for Additional Contacts~~',
@@ -121,7 +137,4 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
-
-	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
-	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/da.dict.itop-standard-email-synchro.php
+++ b/dictionaries/da.dict.itop-standard-email-synchro.php
@@ -20,6 +20,14 @@ Dict::Add('DA DA', 'Danish', 'Dansk', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Put the mail in error: Nothing is done. The mail is in error.
+- Create a new ticket
+- Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',

--- a/dictionaries/da.dict.itop-standard-email-synchro.php
+++ b/dictionaries/da.dict.itop-standard-email-synchro.php
@@ -20,7 +20,7 @@ Dict::Add('DA DA', 'Danish', 'Dansk', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
 - Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
 - Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.

--- a/dictionaries/da.dict.itop-standard-email-synchro.php
+++ b/dictionaries/da.dict.itop-standard-email-synchro.php
@@ -22,10 +22,12 @@ Dict::Add('DA DA', 'Danish', 'Dansk', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error: Nothing is done. The mail is in error.
+- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
+- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
@@ -119,4 +121,7 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
+
+	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
+	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/de.dict.itop-standard-email-synchro.php
+++ b/dictionaries/de.dict.itop-standard-email-synchro.php
@@ -20,7 +20,7 @@ Dict::Add('DE DE', 'German', 'Deutsch', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Tickets anlegen oder aktualisieren',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Neue Tickets anlegen',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Vorhandene Tickets aktualisieren',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
 - Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
 - Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.

--- a/dictionaries/de.dict.itop-standard-email-synchro.php
+++ b/dictionaries/de.dict.itop-standard-email-synchro.php
@@ -20,6 +20,14 @@ Dict::Add('DE DE', 'German', 'Deutsch', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Tickets anlegen oder aktualisieren',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Neue Tickets anlegen',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Vorhandene Tickets aktualisieren',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Put the mail in error: Nothing is done. The mail is in error.
+- Create a new ticket
+- Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'Default-Werte für neue Person',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Geben Sie einen Wert für alle Pflichtfelder einer Person an, mit Ausnahme der E-Mail.
 Verwenden Sie eine Feldinitialisierung pro Zeile im folgenden Format: <field_code>:<value>',

--- a/dictionaries/de.dict.itop-standard-email-synchro.php
+++ b/dictionaries/de.dict.itop-standard-email-synchro.php
@@ -20,16 +20,21 @@ Dict::Add('DE DE', 'German', 'Deutsch', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Tickets anlegen oder aktualisieren',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Neue Tickets anlegen',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Vorhandene Tickets aktualisieren',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
-- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior'                     => 'Behavior in case of closed ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Mark the mail as in error
+- Mark the mail as processed, without updating the closed ticket
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:error'         => 'Mark the mail as in error~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:process'       => 'Mark the mail as processed~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:update_ticket' => 'Update the Ticket~~',
+
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject'             => 'Closed ticket autoreply subject~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject+'            => 'If no subject is provided, then the default subject will be: "Re:$subject$"
+You can use the following placeholders : $subject$, $senderName$, $senderFirstName$ and $senderEmail$ in the email subject.~~',
+
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'Default-Werte für neue Person',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Geben Sie einen Wert für alle Pflichtfelder einer Person an, mit Ausnahme der E-Mail.
 Verwenden Sie eine Feldinitialisierung pro Zeile im folgenden Format: <field_code>:<value>',
@@ -103,10 +108,15 @@ Beim Festlegen externer Schlüssel wie \'org_id\', verwenden Sie die ID (oder de
  - E-Mail ablehnen: Die E-Mail als Fehler kennzeichnen und dem Absender mit dem Inhalt von „Ablehnung unbekannter Absender“ antworten',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:create_contact' => 'Neue Person anlegen',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:reject_email' => 'Mail ablehnen',
-	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply' => 'Ablehnungsnachricht bei unbekanntem Melder',
-	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply+' => 'Optionale Antwort an den Absender, die mit der Option „E-Mail ablehnen“ verwendet wird.
-Unbekannte Absender sind E-Mail-Adressen, die mit keiner Person in '.ITOP_APPLICATION_SHORT.' übereinstimmen.
-Wenn dieses Feld leer gelassen wird, wird keine Nachricht an unbekannte Absender gesendet.',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject'  => 'Unknown senders autoreply subject',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject+' => 'If no subject is provided, then the default subject will be: "[iTop]$subject$ - Unknown caller ($senderEmail$)"
+You can use the following placeholders : $subject$ and $senderEmail$ in the email subject.',
+
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply'  => 'Unknown senders rejection reply message',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply+' => 'Optional reply to sender used with option “Reject the eMail”.
+Unknown senders are email addresses which do not correspond to any Person in '.ITOP_APPLICATION_SHORT.'.
+If this field is left empty, then no message is sent to unknown senders
+You can use the following placeholders : $subject$ and $senderEmail$ in the message.~~',
 	'MailInbox:Behavior' => 'Verhalten bei eingehenden Mails',
 	'MailInbox:Caller' => 'Unbekannte Melder',
 	'MailInbox:Errors' => 'Mails mit Fehlern',
@@ -117,7 +127,4 @@ Wenn dieses Feld leer gelassen wird, wird keine Nachricht an unbekannte Absender
 	'MailInboxStandard:DebugTraceNotActive' => 'Aktivieren Sie Debugging für diese Inbox um den Debug-Trace hier zu sehen.',
 	'Menu:MailInboxes' => 'Mail-Inboxen',
 	'Menu:MailInboxes+' => 'Konfiguration von Mail-Inboxen, die nach eingehenden Mails abzuscannen sind',
-
-	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
-	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/de.dict.itop-standard-email-synchro.php
+++ b/dictionaries/de.dict.itop-standard-email-synchro.php
@@ -22,10 +22,12 @@ Dict::Add('DE DE', 'German', 'Deutsch', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Vorhandene Tickets aktualisieren',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error: Nothing is done. The mail is in error.
+- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
+- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'Default-Werte für neue Person',
@@ -115,4 +117,7 @@ Wenn dieses Feld leer gelassen wird, wird keine Nachricht an unbekannte Absender
 	'MailInboxStandard:DebugTraceNotActive' => 'Aktivieren Sie Debugging für diese Inbox um den Debug-Trace hier zu sehen.',
 	'Menu:MailInboxes' => 'Mail-Inboxen',
 	'Menu:MailInboxes+' => 'Konfiguration von Mail-Inboxen, die nach eingehenden Mails abzuscannen sind',
+
+	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
+	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/en.dict.itop-standard-email-synchro.php
+++ b/dictionaries/en.dict.itop-standard-email-synchro.php
@@ -38,7 +38,7 @@ Dict::Add('EN US', 'English', 'English', array(
 - Create or Update: Update a matching Ticket found, otherwise create. 
 - Create new ticket: Every new message creates a new Ticket.
 - Update existing ticket: Update a matching Ticket found, otherwise flag in error.',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
 - Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
 - Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.

--- a/dictionaries/en.dict.itop-standard-email-synchro.php
+++ b/dictionaries/en.dict.itop-standard-email-synchro.php
@@ -38,16 +38,25 @@ Dict::Add('EN US', 'English', 'English', array(
 - Create or Update: Update a matching Ticket found, otherwise create. 
 - Create new ticket: Every new message creates a new Ticket.
 - Update existing ticket: Update a matching Ticket found, otherwise flag in error.',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
-- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior'                     => 'Behavior in case of closed ticket',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Mark the mail as in error
+- Mark the mail as processed, without updating the closed ticket
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:error'         => 'Mark the mail in error',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:process'       => 'Mark the mail as processed',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:new_ticket'    => 'Create a new Ticket',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:update_ticket' => 'Update the Ticket',
+
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject'  => 'Closed ticket autoreply subject',
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject+' => 'If no subject is provided, then the default subject will be: "Re:$subject$"
+You can use the following placeholders : $subject$, $senderName$, $senderFirstName$ and $senderEmail$ in the email subject.',
+
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply'  => 'Closed ticket autoreply message',
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply+' => 'Optional reply to sender used in case of closed ticket.
+If this field is left empty, then no message is sent in case of closed ticket. 
+You can use the following placeholders : $subject$, $senderName$, $senderFirstName$ and $senderEmail$ in the message.',
 
 	'Class:MailInboxStandard/Attribute:email_storage' => 'After processing the eMail',
 	'Class:MailInboxStandard/Attribute:email_storage/Value:keep' => 'Keep it on the mail server',
@@ -102,10 +111,15 @@ One state/stimulus per line, using format <state_code>:<stimulus_code>',
  - Create a new Person: with the sender email and the "New Person\'s Default Values"
  - Reject the eMail: flag the eMail in error and reply to the sender with the content of "Unknown senders rejection reply"',
 
-    'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply' => 'Unknown senders rejection reply',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject'  => 'Unknown senders autoreply subject',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject+' => 'If no subject is provided, then the default subject will be: "[iTop]$subject$ - Unknown caller ($senderEmail$)"
+You can use the following placeholders : $subject$ and $senderEmail$ in the email subject.',
+
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply'  => 'Unknown senders rejection reply message',
     'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply+' => 'Optional reply to sender used with option “Reject the eMail”.
 Unknown senders are email addresses which do not correspond to any Person in '.ITOP_APPLICATION_SHORT.'.
-If this field is left empty, then no message is sent to unknown senders',
+If this field is left empty, then no message is sent to unknown senders
+You can use the following placeholders : $subject$ and $senderEmail$ in the message.',
 
 	'Class:MailInboxStandard/Attribute:trace' => 'Debug trace',
 	'Class:MailInboxStandard/Attribute:trace/Value:yes' => 'Yes',
@@ -150,6 +164,8 @@ Required when forwarding the eMails in error, as most mail servers only relay me
 	'MailInbox:Server' => 'Mailbox Configuration',
 	'MailInbox:Behavior' => 'Behavior on Incoming eMails',
 	'MailInbox:Caller' => 'Unknown Senders',
+	'MailInbox:TicketProcessing'                                        => 'Ticket Processing',
+	'MailInbox:ClosedTickets'                                           => 'Closed Tickets',
 	'MailInbox:Errors' => 'Emails in Error',
 	'MailInbox:OtherContacts' => 'Behavior for Additional Contacts',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes',
@@ -158,6 +174,4 @@ Required when forwarding the eMails in error, as most mail servers only relay me
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.',
 	'MailInbox:NoSubject' => 'No subject',
 
-	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s',
-	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.',
 ));

--- a/dictionaries/en.dict.itop-standard-email-synchro.php
+++ b/dictionaries/en.dict.itop-standard-email-synchro.php
@@ -38,6 +38,14 @@ Dict::Add('EN US', 'English', 'English', array(
 - Create or Update: Update a matching Ticket found, otherwise create. 
 - Create new ticket: Every new message creates a new Ticket.
 - Update existing ticket: Update a matching Ticket found, otherwise flag in error.',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Put the mail in error: Nothing is done. The mail is in error.
+- Create a new ticket
+- Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket',
 
 	'Class:MailInboxStandard/Attribute:email_storage' => 'After processing the eMail',
 	'Class:MailInboxStandard/Attribute:email_storage/Value:keep' => 'Keep it on the mail server',

--- a/dictionaries/en.dict.itop-standard-email-synchro.php
+++ b/dictionaries/en.dict.itop-standard-email-synchro.php
@@ -40,10 +40,12 @@ Dict::Add('EN US', 'English', 'English', array(
 - Update existing ticket: Update a matching Ticket found, otherwise flag in error.',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error: Nothing is done. The mail is in error.
+- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
+- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket',
 
@@ -155,4 +157,7 @@ Required when forwarding the eMails in error, as most mail servers only relay me
 	'MailInboxStandard:DebugTrace' => 'Debug Trace',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.',
 	'MailInbox:NoSubject' => 'No subject',
+
+	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s',
+	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.',
 ));

--- a/dictionaries/en_gb.dict.itop-standard-email-synchro.php
+++ b/dictionaries/en_gb.dict.itop-standard-email-synchro.php
@@ -38,7 +38,7 @@ Dict::Add('EN GB', 'British English', 'British English', array(
 - Create or Update: Update a matching Ticket found, otherwise create. 
 - Create new ticket: Every new message creates a new Ticket.
 - Update existing ticket: Update a matching Ticket found, otherwise flag in error.',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
 - Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
 - Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.

--- a/dictionaries/en_gb.dict.itop-standard-email-synchro.php
+++ b/dictionaries/en_gb.dict.itop-standard-email-synchro.php
@@ -40,10 +40,12 @@ Dict::Add('EN GB', 'British English', 'British English', array(
 - Update existing ticket: Update a matching Ticket found, otherwise flag in error.',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error: Nothing is done. The mail is in error.
+- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
+- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 
@@ -155,4 +157,7 @@ Required when forwarding the eMails in error, as most mail servers only relay me
 	'MailInboxStandard:DebugTrace' => 'Debug Trace',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.',
 	'MailInbox:NoSubject' => 'No subject',
+
+	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
+	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ));

--- a/dictionaries/en_gb.dict.itop-standard-email-synchro.php
+++ b/dictionaries/en_gb.dict.itop-standard-email-synchro.php
@@ -38,16 +38,21 @@ Dict::Add('EN GB', 'British English', 'British English', array(
 - Create or Update: Update a matching Ticket found, otherwise create. 
 - Create new ticket: Every new message creates a new Ticket.
 - Update existing ticket: Update a matching Ticket found, otherwise flag in error.',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
-- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior'                     => 'Behavior in case of closed ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Mark the mail as in error
+- Mark the mail as processed, without updating the closed ticket
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:error'         => 'Mark the mail as in error~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:process'       => 'Mark the mail as processed~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:update_ticket' => 'Update the Ticket~~',
+
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject'  => 'Closed ticket autoreply subject~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject+' => 'If no subject is provided, then the default subject will be: "Re:$subject$"
+You can use the following placeholders : $subject$, $senderName$, $senderFirstName$ and $senderEmail$ in the email subject.~~',
+
 
 	'Class:MailInboxStandard/Attribute:email_storage' => 'After processing the eMail',
 	'Class:MailInboxStandard/Attribute:email_storage/Value:keep' => 'Keep it on the mail server',
@@ -102,10 +107,15 @@ One state/stimulus per line, using format <state_code>:<stimulus_code>',
  - Create a new Person: with the sender email and the "New Person\'s Default Values"
  - Reject the eMail: flag the eMail in error and reply to the sender with the content of "Unknown senders rejection reply"',
 
-	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply' => 'Unknown senders rejection reply',
-    'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply+' => 'Optional reply to sender used with option “Reject the eMail”.
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject'  => 'Unknown senders autoreply subject',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject+' => 'If no subject is provided, then the default subject will be: "[iTop]$subject$ - Unknown caller ($senderEmail$)"
+You can use the following placeholders : $subject$ and $senderEmail$ in the email subject.',
+
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply'  => 'Unknown senders rejection reply message',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply+' => 'Optional reply to sender used with option “Reject the eMail”.
 Unknown senders are email addresses which do not correspond to any Person in '.ITOP_APPLICATION_SHORT.'.
-If this field is left empty, then no message is sent to unknown senders',
+If this field is left empty, then no message is sent to unknown senders
+You can use the following placeholders : $subject$ and $senderEmail$ in the message.~~',
 
 	'Class:MailInboxStandard/Attribute:trace' => 'Debug trace',
 	'Class:MailInboxStandard/Attribute:trace/Value:yes' => 'Yes',
@@ -157,7 +167,4 @@ Required when forwarding the eMails in error, as most mail servers only relay me
 	'MailInboxStandard:DebugTrace' => 'Debug Trace',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.',
 	'MailInbox:NoSubject' => 'No subject',
-
-	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
-	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ));

--- a/dictionaries/en_gb.dict.itop-standard-email-synchro.php
+++ b/dictionaries/en_gb.dict.itop-standard-email-synchro.php
@@ -38,6 +38,14 @@ Dict::Add('EN GB', 'British English', 'British English', array(
 - Create or Update: Update a matching Ticket found, otherwise create. 
 - Create new ticket: Every new message creates a new Ticket.
 - Update existing ticket: Update a matching Ticket found, otherwise flag in error.',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Put the mail in error: Nothing is done. The mail is in error.
+- Create a new ticket
+- Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 
 	'Class:MailInboxStandard/Attribute:email_storage' => 'After processing the eMail',
 	'Class:MailInboxStandard/Attribute:email_storage/Value:keep' => 'Keep it on the mail server',

--- a/dictionaries/es_cr.dict.itop-standard-email-synchro.php
+++ b/dictionaries/es_cr.dict.itop-standard-email-synchro.php
@@ -20,7 +20,7 @@ Dict::Add('ES CR', 'Spanish', 'Español, Castellano', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Crear or Actualizar Tickets',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Crear nuevos Tickets',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Actualizar Tickets existentes',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
 - Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
 - Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.

--- a/dictionaries/es_cr.dict.itop-standard-email-synchro.php
+++ b/dictionaries/es_cr.dict.itop-standard-email-synchro.php
@@ -20,16 +20,21 @@ Dict::Add('ES CR', 'Spanish', 'Español, Castellano', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Crear or Actualizar Tickets',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Crear nuevos Tickets',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Actualizar Tickets existentes',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
-- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior'                     => 'Behavior in case of closed ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Mark the mail as in error
+- Mark the mail as processed, without updating the closed ticket
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:error'         => 'Mark the mail as in error~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:process'       => 'Mark the mail as processed~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:update_ticket' => 'Update the Ticket~~',
+
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject'             => 'Closed ticket autoreply subject~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject+'            => 'If no subject is provided, then the default subject will be: "Re:$subject$"
+You can use the following placeholders : $subject$, $senderName$, $senderFirstName$ and $senderEmail$ in the email subject.~~',
+
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'Valores por Omisión para Nueva Persona',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',
@@ -106,10 +111,16 @@ Do not activate this option for long periods on production since it tends to gen
  - Reject the eMail: flag the eMail in error and reply to the sender with the content of "Unknown senders rejection reply"~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:create_contact' => 'Crear una nueva Persona',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:reject_email' => 'Rechazar el correo',
-	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply' => 'Unknown senders rejection reply~~',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject'  => 'Unknown senders autoreply subject',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject+' => 'If no subject is provided, then the default subject will be: "[iTop]$subject$ - Unknown caller ($senderEmail$)"
+You can use the following placeholders : $subject$ and $senderEmail$ in the email subject.',
+
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply'  => 'Unknown senders rejection reply message',
 	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply+' => 'Optional reply to sender used with option “Reject the eMail”.
 Unknown senders are email addresses which do not correspond to any Person in '.ITOP_APPLICATION_SHORT.'.
-If this field is left empty, then no message is sent to unknown senders~~',
+If this field is left empty, then no message is sent to unknown senders
+You can use the following placeholders : $subject$ and $senderEmail$ in the message.~~',
+
 	'MailInbox:Behavior' => 'Comportamiento de correos Entrantes',
 	'MailInbox:Caller' => 'Requiriente Desconocido',
 	'MailInbox:Errors' => 'Correos con Error',
@@ -120,7 +131,4 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activar la depuración en este buzón para ver traza de depuración aquí.',
 	'Menu:MailInboxes' => 'Buzones de correos Entrantes',
 	'Menu:MailInboxes+' => 'Configuración de buzones para búsqueda de correos Entrantes',
-
-	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
-	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/es_cr.dict.itop-standard-email-synchro.php
+++ b/dictionaries/es_cr.dict.itop-standard-email-synchro.php
@@ -22,10 +22,12 @@ Dict::Add('ES CR', 'Spanish', 'Español, Castellano', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Actualizar Tickets existentes',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error: Nothing is done. The mail is in error.
+- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
+- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'Valores por Omisión para Nueva Persona',
@@ -118,4 +120,7 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activar la depuración en este buzón para ver traza de depuración aquí.',
 	'Menu:MailInboxes' => 'Buzones de correos Entrantes',
 	'Menu:MailInboxes+' => 'Configuración de buzones para búsqueda de correos Entrantes',
+
+	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
+	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/es_cr.dict.itop-standard-email-synchro.php
+++ b/dictionaries/es_cr.dict.itop-standard-email-synchro.php
@@ -20,6 +20,14 @@ Dict::Add('ES CR', 'Spanish', 'Español, Castellano', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Crear or Actualizar Tickets',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Crear nuevos Tickets',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Actualizar Tickets existentes',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Put the mail in error: Nothing is done. The mail is in error.
+- Create a new ticket
+- Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'Valores por Omisión para Nueva Persona',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',

--- a/dictionaries/fr.dict.itop-standard-email-synchro.php
+++ b/dictionaries/fr.dict.itop-standard-email-synchro.php
@@ -20,6 +20,15 @@ Dict::Add('FR FR', 'French', 'Français', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Créer ou mettre à jour un Ticket',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Créer un Ticket',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Mettre à jour un Ticket existant',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Comportement en cas de ticket fermé',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'Si le ticket correspondant à un message reçu est fermé, donne le comportement à adopter :
+- Mettre le message en erreur (ce qui est préférable si les tickets fermés ne sont pas ré-ouvrables),
+- Créer un nouveau ticket,
+- Mettre à jour le ticket fermé. Dans ce cas, il est préférable de configurer un "Stimuli à appliquer" pour réouvrir le ticket.',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Mettre le mail en errreur',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Créer un nouveau Ticket',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Mettre à jour le Ticket',
+
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'Valeurs par défaut pour la nouvelle Personne',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Fournir une valeur pour tous les champs obligatoires de la Personne, sauf l\'email.
 Un champ par ligne, au format <code_attribut>:<valeur>',

--- a/dictionaries/fr.dict.itop-standard-email-synchro.php
+++ b/dictionaries/fr.dict.itop-standard-email-synchro.php
@@ -22,10 +22,12 @@ Dict::Add('FR FR', 'French', 'Français', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Mettre à jour un Ticket existant',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Comportement en cas de ticket fermé',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'Si le ticket correspondant à un message reçu est fermé, donne le comportement à adopter :
-- Mettre le message en erreur (ce qui est préférable si les tickets fermés ne sont pas ré-ouvrables),
+- Mettre le message en erreur et envoyer un mail de réponse automatique : Le mail est en erreur, et une réponse automatique est envoyée à l\'expéditeur pour l\'informer que le ticket est fermé et ne peut pas être mis à jour. C\'est la meilleure option si les tickets fermés ne sont pas ré-ouvrables.
+- Mettre le message en erreur sans envoyer de mail de réponse automatique : 
 - Créer un nouveau ticket,
 - Mettre à jour le ticket fermé. Dans ce cas, il est préférable de configurer un "Stimuli à appliquer" pour réouvrir le ticket.',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Mettre le mail en errreur',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Mettre le mail en erreur et envoyer un mail de réponse automatique',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Mettre le mail en erreur sans envoyer de mail de réponse automatique',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Créer un nouveau Ticket',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Mettre à jour le Ticket',
 
@@ -120,4 +122,7 @@ Si ce champ est laissé vide, alors aucune réponse ne leur est envoyée.',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activez la trace sur cette boîte mail pour voir le résultat ici.',
 	'Menu:MailInboxes' => 'Gestion des Boîtes Mail',
 	'Menu:MailInboxes+' => 'Configuration des Boîtes Mails à scanner',
+
+	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Erreur : ticket fermé pour l\'email % 1$s',
+	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'Cet email correspond à un ticket clos.Veuillez envoyer un nouveau message pour créer un nouveau ticket ou demander à l\'équipe support de le réouvrir pour pouvoir le mettre à jour.',
 ]);

--- a/dictionaries/fr.dict.itop-standard-email-synchro.php
+++ b/dictionaries/fr.dict.itop-standard-email-synchro.php
@@ -20,16 +20,25 @@ Dict::Add('FR FR', 'French', 'Français', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Créer ou mettre à jour un Ticket',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Créer un Ticket',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Mettre à jour un Ticket existant',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Comportement en cas de ticket fermé',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'Si le ticket correspondant à un message reçu est fermé, donne le comportement à adopter :
-- Mettre le message en erreur et envoyer un mail de réponse automatique : Le mail est en erreur, et une réponse automatique est envoyée à l\'expéditeur pour l\'informer que le ticket est fermé et ne peut pas être mis à jour. C\'est la meilleure option si les tickets fermés ne sont pas ré-ouvrables.
-- Mettre le message en erreur sans envoyer de mail de réponse automatique : 
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior'                     => 'Comportement en cas de ticket fermé',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior+'                    => 'Si le ticket correspondant à un message reçu est fermé, donne le comportement à adopter :
+- Mettre le message en erreur
+- Marquer le message comme traité sans mettre à jour le ticket 
 - Créer un nouveau ticket,
 - Mettre à jour le ticket fermé. Dans ce cas, il est préférable de configurer un "Stimuli à appliquer" pour réouvrir le ticket.',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Mettre le mail en erreur et envoyer un mail de réponse automatique',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Mettre le mail en erreur sans envoyer de mail de réponse automatique',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Créer un nouveau Ticket',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Mettre à jour le Ticket',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:error'         => 'Mettre le mail en erreur',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:process'       => 'Marquer le mail comme traité',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:new_ticket'    => 'Créer un nouveau Ticket',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:update_ticket' => 'Mettre à jour le Ticket',
+
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject'  => 'Sujet de la réponse en cas de ticket fermé',
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject+' => 'Si aucun sujet n\'est renseigné, le sujet par défaut sera :: "Re:$subject$"
+Vous pouvez utiliser les placeholders $subject$, $senderName$, $senderFirstName$ et $senderEmail$ dans le sujet du mail.',
+
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply'                     => 'Réponse en cas de ticket fermé',
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply+'                    => 'Auto reply optionnel en cas de ticket fermé.
+Si le champ est vide, aucun message ne sera envoyé en cas de ticket fermé
+Vous pouvez utiliser les placeholders  $subject$, $senderName$, $senderFirstName$ et $senderEmail$ dans le message.',
 
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'Valeurs par défaut pour la nouvelle Personne',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Fournir une valeur pour tous les champs obligatoires de la Personne, sauf l\'email.
@@ -108,12 +117,18 @@ Ne laissez pas cette option activée trop longtemps dans un environnement de pro
  - Rejeter l\'eMail : ce qui le marquera en erreur et répondra avec le contenu du champ \'Réponse aux expéditeurs inconnus\'.',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:create_contact' => 'Créer une nouvelle Personne',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:reject_email' => 'Rejeter l\'eMail',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject'  => 'Sujet de la réponse aux expéditeurs inconnus',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject+' => 'Si aucun sujet n\'est renseigné, le sujet par défaut sera : "[iTop]$subject$ - Unknown caller ($senderEmail$)".
+Vous pouvez utiliser les placeholders $subject$ et $senderEmail$ dans le sujet du mail de réponse.',
 	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply' => 'Réponse aux expéditeurs inconnus',
 	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply+' => 'Ce champ optionnel spécifie le message à envoyer aux expéditeurs inconnus.
 Un expéditeur inconnu est celui dont l\'adresse mail ne correspond à aucune Personne dans '.ITOP_APPLICATION_SHORT.'.
-Si ce champ est laissé vide, alors aucune réponse ne leur est envoyée.',
+Si ce champ est laissé vide, alors aucune réponse ne leur est envoyée.
+Vous pouvez utiliser les placeholders $subject$ et $senderEmail$ dans le message.',
 	'MailInbox:Behavior' => 'Comportement',
 	'MailInbox:Caller' => 'Contacts inconnus',
+	'MailInbox:TicketProcessing'                                                => 'Traitement des tickets',
+	'MailInbox:ClosedTickets'                                                   => 'Tickets fermés',
 	'MailInbox:Errors' => 'eMails en erreur',
 	'MailInbox:NoSubject' => 'Pas de sujet',
 	'MailInbox:OtherContacts' => 'Contacts Additionnels',
@@ -122,7 +137,4 @@ Si ce champ est laissé vide, alors aucune réponse ne leur est envoyée.',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activez la trace sur cette boîte mail pour voir le résultat ici.',
 	'Menu:MailInboxes' => 'Gestion des Boîtes Mail',
 	'Menu:MailInboxes+' => 'Configuration des Boîtes Mails à scanner',
-
-	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Erreur : ticket fermé pour l\'email % 1$s',
-	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'Cet email correspond à un ticket clos.Veuillez envoyer un nouveau message pour créer un nouveau ticket ou demander à l\'équipe support de le réouvrir pour pouvoir le mettre à jour.',
 ]);

--- a/dictionaries/hu.dict.itop-standard-email-synchro.php
+++ b/dictionaries/hu.dict.itop-standard-email-synchro.php
@@ -20,6 +20,14 @@ Dict::Add('HU HU', 'Hungarian', 'Magyar', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Put the mail in error: Nothing is done. The mail is in error.
+- Create a new ticket
+- Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',

--- a/dictionaries/hu.dict.itop-standard-email-synchro.php
+++ b/dictionaries/hu.dict.itop-standard-email-synchro.php
@@ -20,16 +20,21 @@ Dict::Add('HU HU', 'Hungarian', 'Magyar', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
-- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior'                     => 'Behavior in case of closed ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Mark the mail as in error
+- Mark the mail as processed, without updating the closed ticket
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:error'         => 'Mark the mail as in error~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:process'       => 'Mark the mail as processed~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:update_ticket' => 'Update the Ticket~~',
+
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject'  => 'Closed ticket autoreply subject~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject+' => 'If no subject is provided, then the default subject will be: "Re:$subject$"
+You can use the following placeholders : $subject$, $senderName$, $senderFirstName$ and $senderEmail$ in the email subject.~~',
+
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',
@@ -107,12 +112,20 @@ Do not activate this option for long periods on production since it tends to gen
  - Reject the eMail: flag the eMail in error and reply to the sender with the content of "Unknown senders rejection reply"~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:create_contact' => 'Create a new Person~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:reject_email' => 'Reject the eMail~~',
-	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply' => 'Unknown senders rejection reply~~',
+
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject'  => 'Unknown senders autoreply subject',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject+' => 'If no subject is provided, then the default subject will be: "[iTop]$subject$ - Unknown caller ($senderEmail$)"
+You can use the following placeholders : $subject$ and $senderEmail$ in the email subject.',
+
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply'  => 'Unknown senders rejection reply message',
 	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply+' => 'Optional reply to sender used with option “Reject the eMail”.
 Unknown senders are email addresses which do not correspond to any Person in '.ITOP_APPLICATION_SHORT.'.
-If this field is left empty, then no message is sent to unknown senders~~',
+If this field is left empty, then no message is sent to unknown senders
+You can use the following placeholders : $subject$ and $senderEmail$ in the message.~~',
 	'MailInbox:Behavior' => 'Behavior on Incoming eMails~~',
 	'MailInbox:Caller' => 'Unknown Senders~~',
+	'MailInbox:TicketProcessing'                                        => 'Ticket Processing~~',
+	'MailInbox:ClosedTickets'                                           => 'Closed Tickets~~',
 	'MailInbox:Errors' => 'Emails in Error~~',
 	'MailInbox:NoSubject' => 'No subject~~',
 	'MailInbox:OtherContacts' => 'Behavior for Additional Contacts~~',
@@ -121,7 +134,4 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
-
-	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
-	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/hu.dict.itop-standard-email-synchro.php
+++ b/dictionaries/hu.dict.itop-standard-email-synchro.php
@@ -20,7 +20,7 @@ Dict::Add('HU HU', 'Hungarian', 'Magyar', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
 - Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
 - Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.

--- a/dictionaries/hu.dict.itop-standard-email-synchro.php
+++ b/dictionaries/hu.dict.itop-standard-email-synchro.php
@@ -22,10 +22,12 @@ Dict::Add('HU HU', 'Hungarian', 'Magyar', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error: Nothing is done. The mail is in error.
+- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
+- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
@@ -119,4 +121,7 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
+
+	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
+	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/it.dict.itop-standard-email-synchro.php
+++ b/dictionaries/it.dict.itop-standard-email-synchro.php
@@ -20,6 +20,14 @@ Dict::Add('IT IT', 'Italian', 'Italiano', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Put the mail in error: Nothing is done. The mail is in error.
+- Create a new ticket
+- Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',

--- a/dictionaries/it.dict.itop-standard-email-synchro.php
+++ b/dictionaries/it.dict.itop-standard-email-synchro.php
@@ -20,16 +20,21 @@ Dict::Add('IT IT', 'Italian', 'Italiano', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
-- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior'                     => 'Behavior in case of closed ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Mark the mail as in error
+- Mark the mail as processed, without updating the closed ticket
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:error'         => 'Mark the mail as in error~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:process'       => 'Mark the mail as processed~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:update_ticket' => 'Update the Ticket~~',
+
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject'             => 'Closed ticket autoreply subject~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject+'            => 'If no subject is provided, then the default subject will be: "Re:$subject$"
+You can use the following placeholders : $subject$, $senderName$, $senderFirstName$ and $senderEmail$ in the email subject.~~',
+
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',
@@ -107,12 +112,20 @@ Do not activate this option for long periods on production since it tends to gen
  - Reject the eMail: flag the eMail in error and reply to the sender with the content of "Unknown senders rejection reply"~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:create_contact' => 'Create a new Person~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:reject_email' => 'Reject the eMail~~',
-	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply' => 'Unknown senders rejection reply~~',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject'  => 'Unknown senders autoreply subject',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject+' => 'If no subject is provided, then the default subject will be: "[iTop]$subject$ - Unknown caller ($senderEmail$)"
+You can use the following placeholders : $subject$ and $senderEmail$ in the email subject.',
+
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply'  => 'Unknown senders rejection reply message',
 	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply+' => 'Optional reply to sender used with option “Reject the eMail”.
 Unknown senders are email addresses which do not correspond to any Person in '.ITOP_APPLICATION_SHORT.'.
-If this field is left empty, then no message is sent to unknown senders~~',
+If this field is left empty, then no message is sent to unknown senders
+You can use the following placeholders : $subject$ and $senderEmail$ in the message.~~',
+
 	'MailInbox:Behavior' => 'Behavior on Incoming eMails~~',
 	'MailInbox:Caller' => 'Unknown Senders~~',
+	'MailInbox:TicketProcessing'                                        => 'Ticket Processing~~',
+	'MailInbox:ClosedTickets'                                           => 'Closed Tickets~~',
 	'MailInbox:Errors' => 'Emails in Error~~',
 	'MailInbox:NoSubject' => 'No subject~~',
 	'MailInbox:OtherContacts' => 'Behavior for Additional Contacts~~',
@@ -121,7 +134,4 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
-
-	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
-	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/it.dict.itop-standard-email-synchro.php
+++ b/dictionaries/it.dict.itop-standard-email-synchro.php
@@ -20,7 +20,7 @@ Dict::Add('IT IT', 'Italian', 'Italiano', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
 - Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
 - Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.

--- a/dictionaries/it.dict.itop-standard-email-synchro.php
+++ b/dictionaries/it.dict.itop-standard-email-synchro.php
@@ -22,10 +22,12 @@ Dict::Add('IT IT', 'Italian', 'Italiano', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error: Nothing is done. The mail is in error.
+- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
+- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
@@ -119,4 +121,7 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
+
+	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
+	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/ja.dict.itop-standard-email-synchro.php
+++ b/dictionaries/ja.dict.itop-standard-email-synchro.php
@@ -22,10 +22,12 @@ Dict::Add('JA JP', 'Japanese', '日本語', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error: Nothing is done. The mail is in error.
+- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
+- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
@@ -119,4 +121,7 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
+
+	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
+	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/ja.dict.itop-standard-email-synchro.php
+++ b/dictionaries/ja.dict.itop-standard-email-synchro.php
@@ -20,16 +20,21 @@ Dict::Add('JA JP', 'Japanese', '日本語', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
-- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior'                     => 'Behavior in case of closed ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Mark the mail as in error
+- Mark the mail as processed, without updating the closed ticket
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:error'         => 'Mark the mail as in error~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:process'       => 'Mark the mail as processed~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:update_ticket' => 'Update the Ticket~~',
+
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject'  => 'Closed ticket autoreply subject~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject+' => 'If no subject is provided, then the default subject will be: "Re:$subject$"
+You can use the following placeholders : $subject$, $senderName$, $senderFirstName$ and $senderEmail$ in the email subject.~~',
+
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',
@@ -107,12 +112,20 @@ Do not activate this option for long periods on production since it tends to gen
  - Reject the eMail: flag the eMail in error and reply to the sender with the content of "Unknown senders rejection reply"~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:create_contact' => 'Create a new Person~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:reject_email' => 'Reject the eMail~~',
-	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply' => 'Unknown senders rejection reply~~',
+
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject'  => 'Unknown senders autoreply subject',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject+' => 'If no subject is provided, then the default subject will be: "[iTop]$subject$ - Unknown caller ($senderEmail$)"
+You can use the following placeholders : $subject$ and $senderEmail$ in the email subject.',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply'          => 'Unknown senders rejection reply message',
 	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply+' => 'Optional reply to sender used with option “Reject the eMail”.
 Unknown senders are email addresses which do not correspond to any Person in '.ITOP_APPLICATION_SHORT.'.
-If this field is left empty, then no message is sent to unknown senders~~',
+If this field is left empty, then no message is sent to unknown senders
+You can use the following placeholders : $subject$ and $senderEmail$ in the message.~~',
+
 	'MailInbox:Behavior' => 'Behavior on Incoming eMails~~',
 	'MailInbox:Caller' => 'Unknown Senders~~',
+	'MailInbox:TicketProcessing'                                                => 'Ticket Processing~~',
+	'MailInbox:ClosedTickets'                                                   => 'Closed Tickets~~',
 	'MailInbox:Errors' => 'Emails in Error~~',
 	'MailInbox:NoSubject' => 'No subject~~',
 	'MailInbox:OtherContacts' => 'Behavior for Additional Contacts~~',
@@ -121,7 +134,4 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
-
-	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
-	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/ja.dict.itop-standard-email-synchro.php
+++ b/dictionaries/ja.dict.itop-standard-email-synchro.php
@@ -20,7 +20,7 @@ Dict::Add('JA JP', 'Japanese', '日本語', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
 - Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
 - Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.

--- a/dictionaries/ja.dict.itop-standard-email-synchro.php
+++ b/dictionaries/ja.dict.itop-standard-email-synchro.php
@@ -20,6 +20,14 @@ Dict::Add('JA JP', 'Japanese', '日本語', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Put the mail in error: Nothing is done. The mail is in error.
+- Create a new ticket
+- Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',

--- a/dictionaries/nl.dict.itop-standard-email-synchro.php
+++ b/dictionaries/nl.dict.itop-standard-email-synchro.php
@@ -20,6 +20,14 @@ Dict::Add('NL NL', 'Dutch', 'Nederlands', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Put the mail in error: Nothing is done. The mail is in error.
+- Create a new ticket
+- Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',

--- a/dictionaries/nl.dict.itop-standard-email-synchro.php
+++ b/dictionaries/nl.dict.itop-standard-email-synchro.php
@@ -20,7 +20,7 @@ Dict::Add('NL NL', 'Dutch', 'Nederlands', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
 - Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
 - Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.

--- a/dictionaries/nl.dict.itop-standard-email-synchro.php
+++ b/dictionaries/nl.dict.itop-standard-email-synchro.php
@@ -22,10 +22,12 @@ Dict::Add('NL NL', 'Dutch', 'Nederlands', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error: Nothing is done. The mail is in error.
+- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
+- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
@@ -119,4 +121,7 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
+
+	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
+	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/nl.dict.itop-standard-email-synchro.php
+++ b/dictionaries/nl.dict.itop-standard-email-synchro.php
@@ -20,16 +20,21 @@ Dict::Add('NL NL', 'Dutch', 'Nederlands', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
-- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior'                     => 'Behavior in case of closed ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Mark the mail as in error
+- Mark the mail as processed, without updating the closed ticket
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:error'         => 'Mark the mail as in error~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:process'       => 'Mark the mail as processed~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:update_ticket' => 'Update the Ticket~~',
+
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject'             => 'Closed ticket autoreply subject~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject+'            => 'If no subject is provided, then the default subject will be: "Re:$subject$"
+You can use the following placeholders : $subject$, $senderName$, $senderFirstName$ and $senderEmail$ in the email subject.~~',
+
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',
@@ -107,12 +112,19 @@ Do not activate this option for long periods on production since it tends to gen
  - Reject the eMail: flag the eMail in error and reply to the sender with the content of "Unknown senders rejection reply"~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:create_contact' => 'Create a new Person~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:reject_email' => 'Reject the eMail~~',
-	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply' => 'Unknown senders rejection reply~~',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject'  => 'Unknown senders autoreply subject',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject+' => 'If no subject is provided, then the default subject will be: "[iTop]$subject$ - Unknown caller ($senderEmail$)"
+You can use the following placeholders : $subject$ and $senderEmail$ in the email subject.',
+
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply'  => 'Unknown senders rejection reply message',
 	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply+' => 'Optional reply to sender used with option “Reject the eMail”.
 Unknown senders are email addresses which do not correspond to any Person in '.ITOP_APPLICATION_SHORT.'.
-If this field is left empty, then no message is sent to unknown senders~~',
+If this field is left empty, then no message is sent to unknown senders
+You can use the following placeholders : $subject$ and $senderEmail$ in the message.~~',
 	'MailInbox:Behavior' => 'Behavior on Incoming eMails~~',
 	'MailInbox:Caller' => 'Unknown Senders~~',
+	'MailInbox:TicketProcessing'                                        => 'Ticket Processing~~',
+	'MailInbox:ClosedTickets'                                           => 'Closed Tickets~~',
 	'MailInbox:Errors' => 'Emails in Error~~',
 	'MailInbox:NoSubject' => 'No subject~~',
 	'MailInbox:OtherContacts' => 'Behavior for Additional Contacts~~',
@@ -121,7 +133,4 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
-
-	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
-	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/pt_br.dict.itop-standard-email-synchro.php
+++ b/dictionaries/pt_br.dict.itop-standard-email-synchro.php
@@ -20,16 +20,21 @@ Dict::Add('PT BR', 'Brazilian', 'Brazilian', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
-- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior'                     => 'Behavior in case of closed ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Mark the mail as in error
+- Mark the mail as processed, without updating the closed ticket
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:error'         => 'Mark the mail as in error~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:process'       => 'Mark the mail as processed~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:update_ticket' => 'Update the Ticket~~',
+
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject'             => 'Closed ticket autoreply subject~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject+'            => 'If no subject is provided, then the default subject will be: "Re:$subject$"
+You can use the following placeholders : $subject$, $senderName$, $senderFirstName$ and $senderEmail$ in the email subject.~~',
+
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',
@@ -107,12 +112,19 @@ Do not activate this option for long periods on production since it tends to gen
  - Reject the eMail: flag the eMail in error and reply to the sender with the content of "Unknown senders rejection reply"~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:create_contact' => 'Create a new Person~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:reject_email' => 'Reject the eMail~~',
-	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply' => 'Unknown senders rejection reply~~',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject'  => 'Unknown senders autoreply subject',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject+' => 'If no subject is provided, then the default subject will be: "[iTop]$subject$ - Unknown caller ($senderEmail$)"
+You can use the following placeholders : $subject$ and $senderEmail$ in the email subject.',
+
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply'  => 'Unknown senders rejection reply message',
 	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply+' => 'Optional reply to sender used with option “Reject the eMail”.
 Unknown senders are email addresses which do not correspond to any Person in '.ITOP_APPLICATION_SHORT.'.
-If this field is left empty, then no message is sent to unknown senders~~',
+If this field is left empty, then no message is sent to unknown senders
+You can use the following placeholders : $subject$ and $senderEmail$ in the message.~~',
 	'MailInbox:Behavior' => 'Behavior on Incoming eMails~~',
 	'MailInbox:Caller' => 'Unknown Senders~~',
+	'MailInbox:TicketProcessing'                                        => 'Ticket Processing~~',
+	'MailInbox:ClosedTickets'                                           => 'Closed Tickets~~',
 	'MailInbox:Errors' => 'Emails in Error~~',
 	'MailInbox:NoSubject' => 'No subject~~',
 	'MailInbox:OtherContacts' => 'Behavior for Additional Contacts~~',
@@ -121,7 +133,4 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
-
-	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
-	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/pt_br.dict.itop-standard-email-synchro.php
+++ b/dictionaries/pt_br.dict.itop-standard-email-synchro.php
@@ -20,6 +20,14 @@ Dict::Add('PT BR', 'Brazilian', 'Brazilian', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Put the mail in error: Nothing is done. The mail is in error.
+- Create a new ticket
+- Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',

--- a/dictionaries/pt_br.dict.itop-standard-email-synchro.php
+++ b/dictionaries/pt_br.dict.itop-standard-email-synchro.php
@@ -20,7 +20,7 @@ Dict::Add('PT BR', 'Brazilian', 'Brazilian', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
 - Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
 - Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.

--- a/dictionaries/pt_br.dict.itop-standard-email-synchro.php
+++ b/dictionaries/pt_br.dict.itop-standard-email-synchro.php
@@ -22,10 +22,12 @@ Dict::Add('PT BR', 'Brazilian', 'Brazilian', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error: Nothing is done. The mail is in error.
+- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
+- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
@@ -119,4 +121,7 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
+
+	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
+	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/ru.dict.itop-standard-email-synchro.php
+++ b/dictionaries/ru.dict.itop-standard-email-synchro.php
@@ -21,16 +21,21 @@ Dict::Add('RU RU', 'Russian', 'Русский', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Создать или обновить тикет',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Создать новый тикет',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Обновить существующий тикета',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
-- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior'                     => 'Behavior in case of closed ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Mark the mail as in error
+- Mark the mail as processed, without updating the closed ticket
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:error'         => 'Mark the mail as in error~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:process'       => 'Mark the mail as processed~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:update_ticket' => 'Update the Ticket~~',
+
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject'             => 'Closed ticket autoreply subject~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject+'            => 'If no subject is provided, then the default subject will be: "Re:$subject$"
+You can use the following placeholders : $subject$, $senderName$, $senderFirstName$ and $senderEmail$ in the email subject.~~',
+
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'Значения по умолчанию для новой Персоны',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',
@@ -107,10 +112,15 @@ Do not activate this option for long periods on production since it tends to gen
  - Reject the eMail: flag the eMail in error and reply to the sender with the content of "Unknown senders rejection reply"~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:create_contact' => 'Создать новую Персону',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:reject_email' => 'Отклонить сообщение',
-	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply' => 'Unknown senders rejection reply~~',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject'  => 'Unknown senders autoreply subject',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject+' => 'If no subject is provided, then the default subject will be: "[iTop]$subject$ - Unknown caller ($senderEmail$)"
+You can use the following placeholders : $subject$ and $senderEmail$ in the email subject.',
+
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply'  => 'Unknown senders rejection reply message',
 	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply+' => 'Optional reply to sender used with option “Reject the eMail”.
 Unknown senders are email addresses which do not correspond to any Person in '.ITOP_APPLICATION_SHORT.'.
-If this field is left empty, then no message is sent to unknown senders~~',
+If this field is left empty, then no message is sent to unknown senders
+You can use the following placeholders : $subject$ and $senderEmail$ in the message.~~',
 	'MailInbox:Behavior' => 'При входящем сообщении',
 	'MailInbox:Caller' => 'Неизвестный отправитель',
 	'MailInbox:Errors' => 'Сообщение с ошибкой',
@@ -121,7 +131,4 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Включите отладку в настройках почтового ящика, чтобы увидеть трассировки.',
 	'Menu:MailInboxes' => 'Входящая почта',
 	'Menu:MailInboxes+' => 'Настройка почтовых ящиков для входящих сообщений электронной почты',
-
-	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
-	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/ru.dict.itop-standard-email-synchro.php
+++ b/dictionaries/ru.dict.itop-standard-email-synchro.php
@@ -23,10 +23,12 @@ Dict::Add('RU RU', 'Russian', 'Русский', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Обновить существующий тикета',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error: Nothing is done. The mail is in error.
+- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
+- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'Значения по умолчанию для новой Персоны',
@@ -119,4 +121,7 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Включите отладку в настройках почтового ящика, чтобы увидеть трассировки.',
 	'Menu:MailInboxes' => 'Входящая почта',
 	'Menu:MailInboxes+' => 'Настройка почтовых ящиков для входящих сообщений электронной почты',
+
+	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
+	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/ru.dict.itop-standard-email-synchro.php
+++ b/dictionaries/ru.dict.itop-standard-email-synchro.php
@@ -21,6 +21,14 @@ Dict::Add('RU RU', 'Russian', 'Русский', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Создать или обновить тикет',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Создать новый тикет',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Обновить существующий тикета',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Put the mail in error: Nothing is done. The mail is in error.
+- Create a new ticket
+- Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'Значения по умолчанию для новой Персоны',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',

--- a/dictionaries/ru.dict.itop-standard-email-synchro.php
+++ b/dictionaries/ru.dict.itop-standard-email-synchro.php
@@ -21,7 +21,7 @@ Dict::Add('RU RU', 'Russian', 'Русский', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Создать или обновить тикет',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Создать новый тикет',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Обновить существующий тикета',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
 - Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
 - Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.

--- a/dictionaries/sk.dict.itop-standard-email-synchro.php
+++ b/dictionaries/sk.dict.itop-standard-email-synchro.php
@@ -20,6 +20,14 @@ Dict::Add('SK SK', 'Slovak', 'Slovenčina', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Put the mail in error: Nothing is done. The mail is in error.
+- Create a new ticket
+- Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',

--- a/dictionaries/sk.dict.itop-standard-email-synchro.php
+++ b/dictionaries/sk.dict.itop-standard-email-synchro.php
@@ -20,7 +20,7 @@ Dict::Add('SK SK', 'Slovak', 'Slovenčina', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
 - Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
 - Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.

--- a/dictionaries/sk.dict.itop-standard-email-synchro.php
+++ b/dictionaries/sk.dict.itop-standard-email-synchro.php
@@ -20,16 +20,21 @@ Dict::Add('SK SK', 'Slovak', 'Slovenčina', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
-- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior'                     => 'Behavior in case of closed ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Mark the mail as in error
+- Mark the mail as processed, without updating the closed ticket
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:error'         => 'Mark the mail as in error~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:process'       => 'Mark the mail as processed~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:update_ticket' => 'Update the Ticket~~',
+
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject'             => 'Closed ticket autoreply subject~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject+'            => 'If no subject is provided, then the default subject will be: "Re:$subject$"
+You can use the following placeholders : $subject$, $senderName$, $senderFirstName$ and $senderEmail$ in the email subject.~~',
+
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',
@@ -107,12 +112,19 @@ Do not activate this option for long periods on production since it tends to gen
  - Reject the eMail: flag the eMail in error and reply to the sender with the content of "Unknown senders rejection reply"~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:create_contact' => 'Create a new Person~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:reject_email' => 'Reject the eMail~~',
-	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply' => 'Unknown senders rejection reply~~',
-	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply+' => 'Optional reply to sender used with option “Reject the eMail”.
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject'  => 'Unknown senders autoreply subject~~',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject+' => 'If no subject is provided, then the default subject will be: "[iTop]$subject$ - Unknown caller ($senderEmail$)"
+You can use the following placeholders : $subject$ and $senderEmail$ in the email subject.~~',
+
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply'  => 'Unknown senders rejection reply message~~',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply+' => 'Optional reply to sender used with option “Reject the eMail~~”.
 Unknown senders are email addresses which do not correspond to any Person in '.ITOP_APPLICATION_SHORT.'.
-If this field is left empty, then no message is sent to unknown senders~~',
+If this field is left empty, then no message is sent to unknown senders
+You can use the following placeholders : $subject$ and $senderEmail$ in the message.',
 	'MailInbox:Behavior' => 'Behavior on Incoming eMails~~',
 	'MailInbox:Caller' => 'Unknown Senders~~',
+	'MailInbox:TicketProcessing'                                        => 'Ticket Processing~~',
+	'MailInbox:ClosedTickets'                                           => 'Closed Tickets~~',
 	'MailInbox:Errors' => 'Emails in Error~~',
 	'MailInbox:NoSubject' => 'No subject~~',
 	'MailInbox:OtherContacts' => 'Behavior for Additional Contacts~~',
@@ -121,7 +133,4 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
-
-	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
-	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/sk.dict.itop-standard-email-synchro.php
+++ b/dictionaries/sk.dict.itop-standard-email-synchro.php
@@ -22,10 +22,12 @@ Dict::Add('SK SK', 'Slovak', 'Slovenčina', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error: Nothing is done. The mail is in error.
+- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
+- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
@@ -119,4 +121,7 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
+
+	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
+	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/tr.dict.itop-standard-email-synchro.php
+++ b/dictionaries/tr.dict.itop-standard-email-synchro.php
@@ -20,16 +20,21 @@ Dict::Add('TR TR', 'Turkish', 'Türkçe', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
-- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior'                     => 'Behavior in case of closed ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Mark the mail as in error
+- Mark the mail as processed, without updating the closed ticket
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:error'         => 'Mark the mail as in error~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:process'       => 'Mark the mail as processed~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:update_ticket' => 'Update the Ticket~~',
+
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject'             => 'Closed ticket autoreply subject~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject+'            => 'If no subject is provided, then the default subject will be: "Re:$subject$"
+You can use the following placeholders : $subject$, $senderName$, $senderFirstName$ and $senderEmail$ in the email subject.~~',
+
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',
@@ -107,12 +112,19 @@ Do not activate this option for long periods on production since it tends to gen
  - Reject the eMail: flag the eMail in error and reply to the sender with the content of "Unknown senders rejection reply"~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:create_contact' => 'Create a new Person~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:reject_email' => 'Reject the eMail~~',
-	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply' => 'Unknown senders rejection reply~~',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject'  => 'Unknown senders autoreply subject',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject+' => 'If no subject is provided, then the default subject will be: "[iTop]$subject$ - Unknown caller ($senderEmail$)"
+You can use the following placeholders : $subject$ and $senderEmail$ in the email subject.',
+
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply'  => 'Unknown senders rejection reply message',
 	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply+' => 'Optional reply to sender used with option “Reject the eMail”.
 Unknown senders are email addresses which do not correspond to any Person in '.ITOP_APPLICATION_SHORT.'.
-If this field is left empty, then no message is sent to unknown senders~~',
+If this field is left empty, then no message is sent to unknown senders
+You can use the following placeholders : $subject$ and $senderEmail$ in the message.~~',
 	'MailInbox:Behavior' => 'Behavior on Incoming eMails~~',
 	'MailInbox:Caller' => 'Unknown Senders~~',
+	'MailInbox:TicketProcessing'                                        => 'Ticket Processing~~',
+	'MailInbox:ClosedTickets'                                           => 'Closed Tickets~~',
 	'MailInbox:Errors' => 'Emails in Error~~',
 	'MailInbox:NoSubject' => 'No subject~~',
 	'MailInbox:OtherContacts' => 'Behavior for Additional Contacts~~',
@@ -121,7 +133,4 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
-
-	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
-	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/tr.dict.itop-standard-email-synchro.php
+++ b/dictionaries/tr.dict.itop-standard-email-synchro.php
@@ -22,10 +22,12 @@ Dict::Add('TR TR', 'Turkish', 'Türkçe', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error: Nothing is done. The mail is in error.
+- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
+- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
@@ -119,4 +121,7 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
+
+	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
+	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/tr.dict.itop-standard-email-synchro.php
+++ b/dictionaries/tr.dict.itop-standard-email-synchro.php
@@ -20,6 +20,14 @@ Dict::Add('TR TR', 'Turkish', 'Türkçe', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Put the mail in error: Nothing is done. The mail is in error.
+- Create a new ticket
+- Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',

--- a/dictionaries/tr.dict.itop-standard-email-synchro.php
+++ b/dictionaries/tr.dict.itop-standard-email-synchro.php
@@ -20,7 +20,7 @@ Dict::Add('TR TR', 'Turkish', 'Türkçe', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
 - Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
 - Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.

--- a/dictionaries/zh_cn.dict.itop-standard-email-synchro.php
+++ b/dictionaries/zh_cn.dict.itop-standard-email-synchro.php
@@ -20,7 +20,7 @@ Dict::Add('ZH CN', 'Chinese', '简体中文', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
 - Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
 - Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.

--- a/dictionaries/zh_cn.dict.itop-standard-email-synchro.php
+++ b/dictionaries/zh_cn.dict.itop-standard-email-synchro.php
@@ -20,6 +20,14 @@ Dict::Add('ZH CN', 'Chinese', '简体中文', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Put the mail in error: Nothing is done. The mail is in error.
+- Create a new ticket
+- Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',

--- a/dictionaries/zh_cn.dict.itop-standard-email-synchro.php
+++ b/dictionaries/zh_cn.dict.itop-standard-email-synchro.php
@@ -20,16 +20,21 @@ Dict::Add('ZH CN', 'Chinese', '简体中文', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket' => 'Behavior in case of closed ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
-- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior'                     => 'Behavior in case of closed ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
+- Mark the mail as in error
+- Mark the mail as processed, without updating the closed ticket
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:error'         => 'Mark the mail as in error~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:process'       => 'Mark the mail as processed~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:new_ticket'    => 'Create a new Ticket~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_behavior/Value:update_ticket' => 'Update the Ticket~~',
+
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject'             => 'Closed ticket autoreply subject~~',
+	'Class:MailInboxStandard/Attribute:closed_ticket_reply_subject+'            => 'If no subject is provided, then the default subject will be: "Re:$subject$"
+You can use the following placeholders : $subject$, $senderName$, $senderFirstName$ and $senderEmail$ in the email subject.~~',
+
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values+' => 'Provide a value for all mandatory fields of a Person, except email.
 Use one field initialization per line, in the format: <field_code>:<value>~~',
@@ -107,12 +112,19 @@ Do not activate this option for long periods on production since it tends to gen
  - Reject the eMail: flag the eMail in error and reply to the sender with the content of "Unknown senders rejection reply"~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:create_contact' => 'Create a new Person~~',
 	'Class:MailInboxStandard/Attribute:unknown_caller_behavior/Value:reject_email' => 'Reject the eMail~~',
-	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply' => 'Unknown senders rejection reply~~',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject'  => 'Unknown senders autoreply subject',
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply_subject+' => 'If no subject is provided, then the default subject will be: "[iTop]$subject$ - Unknown caller ($senderEmail$)"
+You can use the following placeholders : $subject$ and $senderEmail$ in the email subject.',
+
+	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply'  => 'Unknown senders rejection reply message',
 	'Class:MailInboxStandard/Attribute:unknown_caller_rejection_reply+' => 'Optional reply to sender used with option “Reject the eMail”.
 Unknown senders are email addresses which do not correspond to any Person in '.ITOP_APPLICATION_SHORT.'.
-If this field is left empty, then no message is sent to unknown senders~~',
+If this field is left empty, then no message is sent to unknown senders
+You can use the following placeholders : $subject$ and $senderEmail$ in the message.~~',
 	'MailInbox:Behavior' => 'Behavior on Incoming eMails~~',
 	'MailInbox:Caller' => 'Unknown Senders~~',
+	'MailInbox:TicketProcessing'                                        => 'Ticket Processing~~',
+	'MailInbox:ClosedTickets'                                           => 'Closed Tickets~~',
 	'MailInbox:Errors' => 'Emails in Error~~',
 	'MailInbox:NoSubject' => 'No subject~~',
 	'MailInbox:OtherContacts' => 'Behavior for Additional Contacts~~',
@@ -121,7 +133,4 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
-
-	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
-	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);

--- a/dictionaries/zh_cn.dict.itop-standard-email-synchro.php
+++ b/dictionaries/zh_cn.dict.itop-standard-email-synchro.php
@@ -22,10 +22,12 @@ Dict::Add('ZH CN', 'Chinese', '简体中文', [
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket'                     => 'Behavior in case of ticket closed~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket+'                    => 'In case of an update, it provides the behavior if the ticket is closed:
-- Put the mail in error: Nothing is done. The mail is in error.
+- Put the mail in error and send an autoreply: Nothing is done. The mail is in error. An autoreply is sent to the sender with the content of "Closed tickets auto-reply". This is the recommended option to inform users that their update has not been processed because the ticket is closed.
+- Put the mail in error: Nothing is done. The mail is in error. without sending any autoreply to the sender.
 - Create a new ticket
 - Update existing ticket. In this case, it\'s preferable to configure a "stimulus to apply" to reopen ticket.~~',
-	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error'         => 'Put the mail in error~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error_with_autoreply' => 'Put the mail in error and send an auto-reply to the sender~~',
+	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:error' => 'Put the mail in error without autoreply~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:new_ticket'    => 'Create a new Ticket~~',
 	'Class:MailInboxStandard/Attribute:behavior_closed_ticket/Value:update_ticket' => 'Update the Ticket~~',
 	'Class:MailInboxStandard/Attribute:caller_default_values' => 'New Person\'s Default Values~~',
@@ -119,4 +121,7 @@ If this field is left empty, then no message is sent to unknown senders~~',
 	'MailInboxStandard:DebugTraceNotActive' => 'Activate the debug on this Inbox to see the debug trace here.~~',
 	'Menu:MailInboxes' => 'Incoming eMail Inboxes~~',
 	'Menu:MailInboxes+' => 'Configuration of Inboxes to scan for Incoming eMails~~',
+
+	'itop-standard-email-synchro:email_subject_error_closed_ticket' => 'Error: closed ticket for email %1$s~~',
+	'itop-standard-email-synchro:email_message_error_closed_ticket' => 'This eMail was received for a ticket which is closed. Please send a new eMail to create a new ticket or ask the support team to reopen the ticket if you want to update it.~~',
 ]);


### PR DESCRIPTION
Add a new field: 'Behavior in case of closed ticket' with 4 values : 
- Put the mail in error and send an auto-reply to the sender
- Put the mail in error without autoreply
- Create a new Ticket
- Update the Ticket