### PR TITLE
N°3393 N°9718 - Remove calls to deprecated files/classes

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -1,9 +1,10 @@
 <?php
+
 // Copyright (C) 2013 Combodo SARL
 //
 //   This file is part of iTop.
 //
-//   iTop is free software; you can redistribute it and/or modify	
+//   iTop is free software; you can redistribute it and/or modify
 //   it under the terms of the GNU Affero General Public License as published by
 //   the Free Software Foundation, either version 3 of the License, or
 //   (at your option) any later version.
@@ -25,44 +26,36 @@
 require_once('../../approot.inc.php');
 require_once(APPROOT.'/application/application.inc.php');
 
-try
-{
+use Combodo\iTop\Application\WebPage\AjaxPage;
+
+try {
 	require_once(APPROOT.'/application/cmdbabstract.class.inc.php');
 	require_once(APPROOT.'/application/startup.inc.php');
-	
+
 	require_once(APPROOT.'/application/loginwebpage.class.inc.php');
 	LoginWebPage::DoLogin(false /* bMustBeAdmin */, false /* IsAllowedToPortalUsers */); // Check user rights and prompt if needed
 
-    $oPage = new AjaxPage('');
+	$oPage = new AjaxPage('');
 
 	$sOperation = utils::ReadParam('operation', '');
 	$iMailInboxId = utils::ReadParam('id', 0, false, 'raw_data');
-	
-	switch($sOperation)
-	{
+
+	switch ($sOperation) {
 		case 'debug_trace':
-		$oInbox = MetaModel::GetObject('MailInboxBase', $iMailInboxId, false);
-		if(is_object($oInbox))
-		{
-			if ($oInbox->Get('trace') == 'yes')
-			{
-				$oPage->add('<pre>'.htmlentities($oInbox->Get('debug_trace'), ENT_QUOTES, 'UTF-8').'</pre>');
+			$oInbox = MetaModel::GetObject('MailInboxBase', $iMailInboxId, false);
+			if (is_object($oInbox)) {
+				if ($oInbox->Get('trace') == 'yes') {
+					$oPage->add('<pre>'.htmlentities($oInbox->Get('debug_trace'), ENT_QUOTES, 'UTF-8').'</pre>');
+				} else {
+					$oPage->p(Dict::Format('MailInboxStandard:DebugTraceNotActive'));
+				}
+			} else {
+				$oPage->P(Dict::S('UI:ObjectDoesNotExist'));
 			}
-			else
-			{
-				$oPage->p(Dict::Format('MailInboxStandard:DebugTraceNotActive'));					
-			}
-		}
-		else
-		{
-			$oPage->P(Dict::S('UI:ObjectDoesNotExist'));
-		}
-		break;
+			break;
 	}
 	$oPage->output();
-}
-catch(Exception $e)
-{	
+} catch (Exception $e) {
 	$oPage->SetContentType('text/html');
 	$oPage->add($e->getMessage());
 	$oPage->output();

--- a/ajax.php
+++ b/ajax.php
@@ -24,7 +24,6 @@
 
 require_once('../../approot.inc.php');
 require_once(APPROOT.'/application/application.inc.php');
-require_once(APPROOT.'/application/ajaxwebpage.class.inc.php');
 
 try
 {
@@ -34,11 +33,7 @@ try
 	require_once(APPROOT.'/application/loginwebpage.class.inc.php');
 	LoginWebPage::DoLogin(false /* bMustBeAdmin */, false /* IsAllowedToPortalUsers */); // Check user rights and prompt if needed
 
-	if (version_compare(ITOP_DESIGN_LATEST_VERSION , '3.0') < 0) {
-		$oPage = new ajax_page('');
-	} else {
-		$oPage = new AjaxPage('');
-	}
+    $oPage = new AjaxPage('');
 
 	$sOperation = utils::ReadParam('operation', '');
 	$iMailInboxId = utils::ReadParam('id', 0, false, 'raw_data');


### PR DESCRIPTION
<!--

IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.

-->

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N°3393 N°9718
| Type of change?                                               | Bug fix

## Symptom (bug) / Objective (enhancement)
When displaying debug tab with iTop 3.3.0, an error appears where ajax.php tries to include deprecated (now removed) ajaxwebpage file


## Reproduction procedure (bug)

1. On iTop 3.3.0-dev
2. With latest mail to ticket version
3. Configure an OAuth 2 mailbox
5. On the mailbox, go to the "Debug" tab
6. See the error

## Cause (bug)
`ajaxwebpage.class.inc.php` file has been removed from iTop 3.3.
It's now time to retire compatibility with iTop 2.7 that this bit of code used


## Proposed solution (bug and enhancement)
Remove calls to 2.7 compatibility code


## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance (test on 3.3 and 3.2)
- [X] Is the PR clear and detailed enough so anyone can understand without digging in the code?
